### PR TITLE
spectator grid tweaks

### DIFF
--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -1550,7 +1550,7 @@ namespace osu.Game
                 else
                     Toolbar.Show();
 
-                if (newOsuScreen.AllowBackButton)
+                if (newOsuScreen.AllowBackButton && newOsuScreen.ShowBackButton)
                     BackButton.Show();
                 else
                     BackButton.Hide();

--- a/osu.Game/Screens/IOsuScreen.cs
+++ b/osu.Game/Screens/IOsuScreen.cs
@@ -25,6 +25,8 @@ namespace osu.Game.Screens
         /// </summary>
         bool AllowBackButton { get; }
 
+        bool ShowBackButton { get; }
+
         /// <summary>
         /// Whether a footer (and a back button) should be displayed underneath the screen.
         /// </summary>

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerMatchFooter.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerMatchFooter.cs
@@ -3,8 +3,15 @@
 
 #nullable disable
 
+using System;
+using System.Drawing;
+using osu.Framework.Allocation;
+using osu.Framework.Configuration;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Graphics.UserInterfaceV2;
+using osuTK;
 
 namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
 {
@@ -12,6 +19,45 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
     {
         private const float ready_button_width = 600;
         private const float spectate_button_width = 200;
+
+        private readonly OsuNumberBox numberBox;
+        private readonly OsuButton setResolutionButton;
+
+        private const int minimum_window_height = 720;
+        private const int maximum_window_height = 2160;
+        private const float aspect_ratio = 1920f / 720f;
+        private const float height_reduction_ratio = 720f / 1080f; // active area height is 720 for a 1080p stream
+        private const int stream_area_width = 1366;
+
+        [BackgroundDependencyLoader]
+        private void load(FrameworkConfigManager frameworkConfig)
+        {
+            var windowSize = frameworkConfig.GetBindable<Size>(FrameworkSetting.WindowedSize);
+
+            setResolutionButton.Action = () =>
+            {
+                if (string.IsNullOrEmpty(numberBox.Text))
+                    return;
+
+                // box contains text
+                if (!int.TryParse(numberBox.Text, out int height))
+                {
+                    // at this point, the only reason we can arrive here is if the input number was too big to parse into an int
+                    // so clamp to max allowed value
+                    height = maximum_window_height;
+                }
+                else
+                {
+                    height = Math.Clamp(height, minimum_window_height, maximum_window_height);
+                }
+
+                // in case number got clamped, reset number in numberBox
+                numberBox.Text = height.ToString();
+
+                height = (int)(height_reduction_ratio * height);
+                windowSize.Value = new Size((int)(height * aspect_ratio), height);
+            };
+        }
 
         public MultiplayerMatchFooter()
         {
@@ -25,11 +71,23 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
                     new Drawable[]
                     {
                         null,
+                        numberBox = new OsuNumberBox
+                        {
+                            Text = "1080",
+                            RelativeSizeAxes = Axes.Both,
+                            Size = Vector2.One
+                        },
+                        null,
+                        setResolutionButton = new RoundedButton
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Size = Vector2.One,
+                            Text = "Set stream height",
+                        },
                         new MultiplayerSpectateButton
                         {
                             RelativeSizeAxes = Axes.Both,
                         },
-                        null,
                         new MatchStartControl
                         {
                             RelativeSizeAxes = Axes.Both,

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorScreen.cs
@@ -287,6 +287,8 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
             syncManager.RemoveManagedClock(instance.SpectatorPlayerClock);
         });
 
+        public override bool AllowBackButton => false;
+
         public override bool OnBackButton()
         {
             if (multiplayerClient.Room == null)

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorScreen.cs
@@ -11,6 +11,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Logging;
 using osu.Game.Graphics;
 using osu.Game.Online.Multiplayer;
+using osu.Game.Online.Multiplayer.MatchTypes.TeamVersus;
 using osu.Game.Online.Rooms;
 using osu.Game.Online.Spectator;
 using osu.Game.Screens.Play;
@@ -59,18 +60,27 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
         private readonly Room room;
         private readonly MultiplayerRoomUser[] users;
 
+        private static MultiplayerRoomUser[] sortUsersByTeam(MultiplayerRoomUser[] users)
+        {
+            // check if users have team info, otherwise leave unchanged
+            if ((users.FirstOrDefault()?.MatchState as TeamVersusUserState)?.TeamID == null)
+                return users;
+
+            return users.OrderBy(u => (u.MatchState as TeamVersusUserState)!.TeamID).ToArray();
+        }
+
         /// <summary>
         /// Creates a new <see cref="MultiSpectatorScreen"/>.
         /// </summary>
         /// <param name="room">The room.</param>
         /// <param name="users">The players to spectate.</param>
         public MultiSpectatorScreen(Room room, MultiplayerRoomUser[] users)
-            : base(users.Select(u => u.UserID).ToArray())
+            : base(sortUsersByTeam(users).Select(u => u.UserID).ToArray())
         {
             this.room = room;
-            this.users = users;
+            this.users = sortUsersByTeam(users);
 
-            instances = new PlayerArea[Users.Count];
+            instances = new PlayerArea[UserIds.Count];
         }
 
         [BackgroundDependencyLoader]
@@ -130,8 +140,8 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
                 }
             };
 
-            for (int i = 0; i < Users.Count; i++)
-                grid.Add(instances[i] = new PlayerArea(Users[i], syncManager.CreateManagedClock()));
+            for (int i = 0; i < Math.Min(PlayerGrid.MAX_PLAYERS, UserIds.Count); i++)
+                grid.Add(instances[i] = new PlayerArea(UserIds[i], syncManager.CreateManagedClock()));
 
             LoadComponentAsync(statisticsTracker = new TournamentSpectatorStatisticsTracker(users), _ =>
             {

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorScreen.cs
@@ -287,7 +287,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
             syncManager.RemoveManagedClock(instance.SpectatorPlayerClock);
         });
 
-        public override bool AllowBackButton => false;
+        public override bool ShowBackButton => false;
 
         public override bool OnBackButton()
         {

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/PlayerGrid.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/PlayerGrid.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
         /// </summary>
         public const int MAX_PLAYERS = 2;
 
-        private const float player_spacing = 0;
+        private const float player_spacing = 1;
 
         /// <summary>
         /// The currently-maximised facade.
@@ -97,6 +97,8 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
 
         private void toggleMaximisationState(Cell target)
         {
+            return;
+
             // in the case the target is the already maximised cell (or there is only one cell), no cell should be maximised.
             bool hasMaximised = !target.IsMaximised && cellContainer.Count > 1;
 

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/PlayerGrid.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/PlayerGrid.cs
@@ -19,12 +19,11 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
         public const float ANIMATION_DELAY = 400;
 
         /// <summary>
-        /// A temporary limitation on the number of players, because only layouts up to 16 players are supported for a single screen.
-        /// Todo: Can be removed in the future with scrolling support + performance improvements.
+        /// LGA: 1v1 tournament
         /// </summary>
-        public const int MAX_PLAYERS = 16;
+        public const int MAX_PLAYERS = 2;
 
-        private const float player_spacing = 6;
+        private const float player_spacing = 0;
 
         /// <summary>
         /// The currently-maximised facade.

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/PlayerGrid_Cell.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/PlayerGrid_Cell.cs
@@ -51,7 +51,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
                 InternalChild = Content = content;
 
                 Masking = true;
-                CornerRadius = 5;
+                CornerRadius = 0;
             }
 
             protected override void Update()

--- a/osu.Game/Screens/OsuScreen.cs
+++ b/osu.Game/Screens/OsuScreen.cs
@@ -39,6 +39,8 @@ namespace osu.Game.Screens
 
         public virtual bool AllowBackButton => true;
 
+        public virtual bool ShowBackButton => true;
+
         public virtual bool ShowFooter => false;
 
         public virtual bool AllowExternalScreenChange => false;

--- a/osu.Game/Screens/Play/SpectatorPlayer.cs
+++ b/osu.Game/Screens/Play/SpectatorPlayer.cs
@@ -3,11 +3,8 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.ObjectExtensions;
-using osu.Framework.Graphics;
 using osu.Framework.Screens;
 using osu.Game.Beatmaps;
-using osu.Game.Graphics;
-using osu.Game.Graphics.Sprites;
 using osu.Game.Online.Spectator;
 using osu.Game.Rulesets.Replays;
 using osu.Game.Rulesets.Replays.Types;
@@ -37,19 +34,6 @@ namespace osu.Game.Screens.Play
             : base(configuration)
         {
             this.score = score;
-        }
-
-        [BackgroundDependencyLoader]
-        private void load()
-        {
-            AddInternal(new OsuSpriteText
-            {
-                Text = $"Watching {score.ScoreInfo.User.Username} playing live!",
-                Font = OsuFont.Default.With(size: 30),
-                Y = 100,
-                Anchor = Anchor.TopCentre,
-                Origin = Anchor.TopCentre,
-            });
         }
 
         protected override void LoadComplete()

--- a/osu.Game/Screens/Spectate/SpectatorScreen.cs
+++ b/osu.Game/Screens/Spectate/SpectatorScreen.cs
@@ -25,9 +25,9 @@ namespace osu.Game.Screens.Spectate
     /// </summary>
     public abstract partial class SpectatorScreen : OsuScreen
     {
-        protected IReadOnlyList<int> Users => users;
+        protected IReadOnlyList<int> UserIds => userIds;
 
-        private readonly List<int> users = new List<int>();
+        private readonly List<int> userIds = new List<int>();
 
         [Resolved]
         private BeatmapManager beatmaps { get; set; } = null!;
@@ -57,14 +57,14 @@ namespace osu.Game.Screens.Spectate
         /// <param name="users">The users to spectate.</param>
         protected SpectatorScreen(params int[] users)
         {
-            this.users.AddRange(users);
+            this.userIds.AddRange(users);
         }
 
         protected override void LoadComplete()
         {
             base.LoadComplete();
 
-            userLookupCache.GetUsersAsync(users.ToArray()).ContinueWith(task => Schedule(() =>
+            userLookupCache.GetUsersAsync(userIds.ToArray()).ContinueWith(task => Schedule(() =>
             {
                 var foundUsers = task.GetResultSafely();
 
@@ -265,7 +265,7 @@ namespace osu.Game.Screens.Spectate
 
             quitGameplay(userId);
 
-            users.Remove(userId);
+            userIds.Remove(userId);
             userMap.Remove(userId);
 
             spectatorClient.StopWatchingUser(userId);


### PR DESCRIPTION
- sort players by team id (if applicable)
- hides back button
- adds a `Set stream height` button to multisubroomscreen
- remove "watching user playing live!" overlay text on each spectator player 