### PR TITLE
defer ipc beatmap commit until room playlist has been updated

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
@@ -81,6 +81,11 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                 Logger.Log($"({nameof(MultiplayerMatchSubScreen)}) tourney state changed to: {TourneyState.Lobby}");
                 TournamentIpc.TourneyState.Value = TourneyState.Lobby;
                 TournamentIpc.TourneyState.TriggerChange();
+
+                SelectedItem.BindValueChanged(vce =>
+                {
+                    TournamentIpc.UpdateActiveBeatmap(vce.NewValue?.Beatmap.OnlineID ?? 0);
+                });
             }
 
             if (!client.IsConnected.Value)

--- a/osu.Game/TournamentIpc/TournamentFileBasedIPC.cs
+++ b/osu.Game/TournamentIpc/TournamentFileBasedIPC.cs
@@ -28,9 +28,6 @@ namespace osu.Game.TournamentIpc
     {
         private Storage tournamentStorage = null!;
 
-        [Resolved]
-        private IBindable<WorkingBeatmap> workingBeatmap { get; set; } = null!;
-
         private MultiplayerClient? multiplayerClient;
 
         public Bindable<TourneyState> TourneyState { get; } = new Bindable<TourneyState>();
@@ -70,15 +67,6 @@ namespace osu.Game.TournamentIpc
                 Logger.Log($@"[FileIPC] Wrote {changedEventArgs.NewItems.Count} message(s) to file");
             }, true);
 
-            workingBeatmap.BindValueChanged(vce =>
-            {
-                using (var mainIpc = tournamentStorage.CreateFileSafely(IpcFiles.BEATMAP))
-                using (var mainIpcStreamWriter = new StreamWriter(mainIpc))
-                {
-                    mainIpcStreamWriter.Write($"{vce.NewValue.BeatmapInfo.OnlineID}\n");
-                }
-            });
-
             Logger.Log($"watching for tourney state changes");
 
             TourneyState.BindValueChanged(vce =>
@@ -107,6 +95,15 @@ namespace osu.Game.TournamentIpc
         public void UpdateTeamScores(long[] scores)
         {
             pendingScores = scores;
+        }
+
+        public void UpdateActiveBeatmap(int beatmapId)
+        {
+            using (var mainIpc = tournamentStorage.CreateFileSafely(IpcFiles.BEATMAP))
+            using (var mainIpcStreamWriter = new StreamWriter(mainIpc))
+            {
+                mainIpcStreamWriter.Write($"{beatmapId}\n");
+            }
         }
 
         public void RegisterMultiplayerRoomClient(MultiplayerClient multiplayerClient)

--- a/osu.Game/TournamentIpc/TournamentFileBasedIPC.cs
+++ b/osu.Game/TournamentIpc/TournamentFileBasedIPC.cs
@@ -9,7 +9,6 @@ using osu.Framework.Graphics;
 using osu.Framework.Logging;
 using osu.Framework.Platform;
 using osu.Framework.Threading;
-using osu.Game.Beatmaps;
 using osu.Game.Online.Chat;
 using osu.Game.Online.Multiplayer;
 


### PR DESCRIPTION
this prevents the ipc beatmap from immediately changing when scrolling through the song carousel