### PR TITLE
fix score displays for DrawableMatchTeam and in GameplayScreen

### DIFF
--- a/osu.Game.Tournament.Tests/Components/TestSceneDrawableTournamentMatch.cs
+++ b/osu.Game.Tournament.Tests/Components/TestSceneDrawableTournamentMatch.cs
@@ -6,6 +6,7 @@ using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Testing;
+using osu.Framework.Utils;
 using osu.Game.Tournament.Models;
 using osu.Game.Tournament.Screens.Ladder.Components;
 
@@ -91,6 +92,102 @@ namespace osu.Game.Tournament.Tests.Components
 
             AddStep("select as current", () => match1.Current.Value = true);
             AddStep("select as editing", () => this.ChildrenOfType<DrawableTournamentMatch>().Last().Selected = true);
+        }
+
+        private void incrementScoresRandom(TournamentMatch match1)
+        {
+            int rand1 = RNG.Next(100_000, 800_000);
+            int rand2 = RNG.Next(100_000, 800_000);
+
+            match1.Team1Score.Value += rand1;
+            match1.Team2Score.Value += rand2;
+        }
+
+        [Test]
+        public void TestCumulative()
+        {
+            Container<DrawableTournamentMatch> level1 = null!;
+            Container<DrawableTournamentMatch> level2 = null!;
+
+            TournamentMatch match1 = null!;
+            TournamentMatch match2 = null!;
+
+            AddStep("setup test", () =>
+            {
+                match1 = new TournamentMatch(
+                    new TournamentTeam { FlagName = { Value = "AU" }, FullName = { Value = "Australia" }, },
+                    new TournamentTeam { FlagName = { Value = "JP" }, FullName = { Value = "Japan" }, Acronym = { Value = "JPN" } })
+                {
+                    Team1Score = { Value = 4 },
+                    Team2Score = { Value = 1 },
+                };
+
+                match2 = new TournamentMatch(
+                    new TournamentTeam
+                    {
+                        FlagName = { Value = "RO" },
+                        FullName = { Value = "Romania" },
+                    }
+                );
+
+                Child = new FillFlowContainer
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Direction = FillDirection.Horizontal,
+                    Children = new Drawable[]
+                    {
+                        level1 = new FillFlowContainer<DrawableTournamentMatch>
+                        {
+                            AutoSizeAxes = Axes.X,
+                            Direction = FillDirection.Vertical,
+                            Children = new[]
+                            {
+                                new DrawableTournamentMatch(match1),
+                                new DrawableTournamentMatch(match2),
+                                new DrawableTournamentMatch(new TournamentMatch()),
+                            }
+                        },
+                        level2 = new FillFlowContainer<DrawableTournamentMatch>
+                        {
+                            AutoSizeAxes = Axes.X,
+                            Direction = FillDirection.Vertical,
+                            Margin = new MarginPadding(20),
+                            Children = new[]
+                            {
+                                new DrawableTournamentMatch(new TournamentMatch()),
+                                new DrawableTournamentMatch(new TournamentMatch())
+                            }
+                        }
+                    }
+                };
+
+                level1.Children[0].Match.Progression.Value = level2.Children[0].Match;
+                level1.Children[1].Match.Progression.Value = level2.Children[0].Match;
+            });
+
+            AddStep("change scores", () => incrementScoresRandom(match1));
+            AddRepeatStep("wait for score to settle", () => { }, 8);
+            AddStep("change scores", () => incrementScoresRandom(match1));
+            AddRepeatStep("wait for score to settle", () => { }, 8);
+            AddStep("change scores", () => incrementScoresRandom(match1));
+            AddRepeatStep("wait for score to settle", () => { }, 8);
+            AddStep("change scores", () => incrementScoresRandom(match1));
+            AddRepeatStep("wait for score to settle", () => { }, 8);
+            // AddStep("add new team", () => match2.Team2.Value = new TournamentTeam { FlagName = { Value = "PT" }, FullName = { Value = "Portugal" } });
+            // AddStep("Add progression", () => level1.Children[2].Match.Progression.Value = level2.Children[1].Match);
+            //
+            // AddStep("start match", () => match2.StartMatch());
+            //
+            // AddRepeatStep("change scores", () => match2.Team1Score.Value++, 10);
+            //
+            // AddStep("start submatch", () => level2.Children[0].Match.StartMatch());
+            //
+            // AddRepeatStep("change scores", () => level2.Children[0].Match.Team1Score.Value++, 5);
+            //
+            // AddRepeatStep("change scores", () => level2.Children[0].Match.Team2Score.Value++, 4);
+            //
+            // AddStep("select as current", () => match1.Current.Value = true);
+            // AddStep("select as editing", () => this.ChildrenOfType<DrawableTournamentMatch>().Last().Selected = true);
         }
     }
 }

--- a/osu.Game.Tournament/Screens/Gameplay/Components/TeamDisplay.cs
+++ b/osu.Game.Tournament/Screens/Gameplay/Components/TeamDisplay.cs
@@ -157,7 +157,7 @@ namespace osu.Game.Tournament.Screens.Gameplay.Components
             currentTeamScore.BindValueChanged(_ =>
             {
                 cumulativeScoreCounter.Current.Value = currentTeamScore.Value ?? 0;
-            });
+            }, true);
         }
 
         protected override void LoadComplete()

--- a/osu.Game.Tournament/Screens/Gameplay/GameplayScreen.cs
+++ b/osu.Game.Tournament/Screens/Gameplay/GameplayScreen.cs
@@ -133,6 +133,7 @@ namespace osu.Game.Tournament.Screens.Gameplay
                             LabelText = "Team red score override",
                             RelativeSizeAxes = Axes.None,
                             Width = 200,
+                            ShowsDefaultIndicator = false,
                             Current = { Default = 0 }
                         },
                         team2ScoreOverride = new SettingsLongNumberBox
@@ -140,6 +141,7 @@ namespace osu.Game.Tournament.Screens.Gameplay
                             LabelText = "Team blue score override",
                             RelativeSizeAxes = Axes.None,
                             Width = 200,
+                            ShowsDefaultIndicator = false,
                             Current = { Default = 0 }
                         },
                         matchCompleteOverride = new OsuCheckbox
@@ -193,12 +195,10 @@ namespace osu.Game.Tournament.Screens.Gameplay
             team1ScoreOverride.Current.BindTo(match.NewValue.Team1Score);
             team2ScoreOverride.Current.UnbindBindings();
             team2ScoreOverride.Current.BindTo(match.NewValue.Team2Score);
-            matchCompleteOverride.Current.UnbindBindings();
-            matchCompleteOverride.Current.BindTo(match.NewValue.Completed);
 
-            // for some reason this is required to make the revert to default button work correctly
-            team1ScoreOverride.Current.Default = 0;
-            team2ScoreOverride.Current.Default = 0;
+            if (match.OldValue != null)
+                matchCompleteOverride.Current.UnbindFrom(match.OldValue.Completed);
+            matchCompleteOverride.Current.BindTo(match.NewValue.Completed);
         }
 
         private ScheduledDelegate? scheduledScreenChange;

--- a/osu.Game.Tournament/Screens/Gameplay/GameplayScreen.cs
+++ b/osu.Game.Tournament/Screens/Gameplay/GameplayScreen.cs
@@ -189,8 +189,11 @@ namespace osu.Game.Tournament.Screens.Gameplay
 
             warmup.Value = match.NewValue.Team1Score.Value + match.NewValue.Team2Score.Value == 0;
             scheduledScreenChange?.Cancel();
+            team1ScoreOverride.Current.UnbindBindings();
             team1ScoreOverride.Current.BindTo(match.NewValue.Team1Score);
+            team2ScoreOverride.Current.UnbindBindings();
             team2ScoreOverride.Current.BindTo(match.NewValue.Team2Score);
+            matchCompleteOverride.Current.UnbindBindings();
             matchCompleteOverride.Current.BindTo(match.NewValue.Completed);
 
             // for some reason this is required to make the revert to default button work correctly


### PR DESCRIPTION
the bindable flow surrounding match switching in the gameplay screen was flawed such that scores between matches would end up synced between each other. in some scenarios, this bad bindable flow handling would also cause a crash.

this PR also does:
- adjust DrawableMatchTeam to widen the score box so that cumulative scores fit
- fix behaviour of the score override/completion controls in GameplayScreen
- fix match score display being 0 when first loading into GameplayScreen and match score not 0