### PR TITLE
fix weird autoadvance behaviours in mappool screen

### DIFF
--- a/osu.Game.Tournament/Screens/MapPool/MapPoolScreen.cs
+++ b/osu.Game.Tournament/Screens/MapPool/MapPoolScreen.cs
@@ -340,7 +340,7 @@ namespace osu.Game.Tournament.Screens.MapPool
 
             setNextMode();
 
-            if (LadderInfo.AutoProgressScreens.Value)
+            if (LadderInfo.AutoProgressScreens.Value && LadderInfo.CumulativeScore.Value == false)
             {
                 if (pickType == ChoiceType.Pick && CurrentMatch.Value.PicksBans.Any(i => i.Type == ChoiceType.Pick))
                 {


### PR DESCRIPTION
mappool screen now no longer auto advances when picking and banning during the draft phase if cumulative score is enabled

mappool screen also automatically goes to gameplay screen if client enters gameplay