### PR TITLE
fix post-ranking screen progression

### DIFF
--- a/osu.Game.Tournament/Screens/Gameplay/GameplayScreen.cs
+++ b/osu.Game.Tournament/Screens/Gameplay/GameplayScreen.cs
@@ -310,7 +310,7 @@ namespace osu.Game.Tournament.Screens.Gameplay
                         {
                             // if we've returned to idle and the last screen was ranking
                             // we should automatically proceed after a short delay
-                            advanceAfterRanking(500);
+                            advanceAfterRanking(50);
                         }
 
                         break;

--- a/osu.Game.Tournament/Screens/MapPool/MapPoolScreen.cs
+++ b/osu.Game.Tournament/Screens/MapPool/MapPoolScreen.cs
@@ -216,7 +216,13 @@ namespace osu.Game.Tournament.Screens.MapPool
                 if (vce.NewValue != TourneyState.Playing || !LadderInfo.AutoProgressScreens.Value) return;
 
                 scheduledScreenChange?.Cancel();
-                scheduledScreenChange = Scheduler.AddDelayed(() => { sceneManager?.SetScreen(typeof(GameplayScreen)); }, 150);
+                scheduledScreenChange = Scheduler.AddDelayed(() =>
+                {
+                    // scheduled screen change could be preempted by manual scene switch, then running when transitioning back from gameplay
+                    if (lazerState.Value != TourneyState.Playing) return;
+
+                    sceneManager?.SetScreen(typeof(GameplayScreen));
+                }, 150);
             });
         }
 

--- a/osu.Game/TournamentIpc/TournamentFileBasedIPC.cs
+++ b/osu.Game/TournamentIpc/TournamentFileBasedIPC.cs
@@ -162,9 +162,7 @@ namespace osu.Game.TournamentIpc
 
                 default:
                     // there is at least one user in results screen
-                    if (multiplayerClient?.Room?.Users.FirstOrDefault(u => u.State == MultiplayerUserState.Results) != null
-                        && multiplayerClient?.LocalUser?.State != MultiplayerUserState.Idle
-                        && TourneyState.Value != TournamentIpc.TourneyState.Lobby)
+                    if (TourneyState.Value != TournamentIpc.TourneyState.Lobby)
                     {
                         Logger.Log($"(room updated) tourney state changed to: {TournamentIpc.TourneyState.Ranking}");
                         TourneyState.Value = TournamentIpc.TourneyState.Ranking;


### PR DESCRIPTION
- state stays in ranking until spectator client returns to lobby/starts next map
- fix bug in tclient where a switch to mappool screen can get cancelled out by a pending scheduled delegate that wasn't run before mappool screen got suspended
- reduce delay from state change to screen switch gameplay -> mappool