### PR TITLE
add combo break indicator

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneComboBreakLayer.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneComboBreakLayer.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Game.Rulesets.Osu;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Screens.Play.HUD;
+
+namespace osu.Game.Tests.Visual.Gameplay
+{
+    public partial class TestSceneComboBreakLayer : OsuTestScene
+    {
+        private readonly Bindable<bool> showHealth = new Bindable<bool>();
+
+        [Cached]
+        private ScoreProcessor scoreProcessor = new ScoreProcessor(new OsuRuleset());
+
+        private void create()
+        {
+            AddStep("create combo break layer", () =>
+            {
+                Child = new ComboBreakLayer
+                {
+                    RelativeSizeAxes = Axes.Both,
+                };
+            });
+
+            AddStep("add argon combo counter", () =>
+            {
+                Add(new ArgonComboCounter());
+            });
+        }
+
+        [Test]
+        public void TestLayerFading()
+        {
+            create();
+
+            AddStep("set high combo", () => scoreProcessor.Combo.Value = 16);
+            AddStep("add more combo", () => scoreProcessor.Combo.Value++);
+            AddStep("reset combo", () => scoreProcessor.Combo.Value = 0);
+        }
+    }
+}

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/PlayerArea.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/PlayerArea.cs
@@ -94,7 +94,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
                 RelativeSizeAxes = Axes.Both,
                 Child = stack = new OsuScreenStack
                 {
-                    Name = nameof(PlayerArea),
+                    Name = $"OsuScreenStack: {nameof(PlayerArea)}",
                 }
             };
 

--- a/osu.Game/Screens/Play/HUD/ComboBreakLayer.cs
+++ b/osu.Game/Screens/Play/HUD/ComboBreakLayer.cs
@@ -1,0 +1,88 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#nullable disable
+
+using osu.Framework.Allocation;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Colour;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Logging;
+using osu.Game.Graphics;
+using osu.Game.Rulesets.Scoring;
+using osuTK.Graphics;
+
+namespace osu.Game.Screens.Play.HUD
+{
+    /// <summary>
+    /// An overlay layer on top of the playfield which flashes red when the current player breaks combo
+    /// </summary>
+    public partial class ComboBreakLayer : CompositeDrawable
+    {
+        private const float max_alpha = 0.4f;
+        private const int fade_time = 400;
+        private const float gradient_size = 0.3f;
+
+        /// <summary>
+        /// The minimum combo that needs to be reached before combo break overlay flashes red on combo break.
+        /// </summary>
+        private const int minimum_combo_threshold = 8;
+
+        private readonly Container boxes;
+
+        private int oldCombo = 0;
+
+        public ComboBreakLayer()
+        {
+            RelativeSizeAxes = Axes.Both;
+            InternalChildren = new Drawable[]
+            {
+                boxes = new Container
+                {
+                    Alpha = 0,
+                    Blending = BlendingParameters.Additive,
+                    RelativeSizeAxes = Axes.Both,
+                    Children = new Drawable[]
+                    {
+                        new Box
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Colour = ColourInfo.GradientHorizontal(Color4.White, Color4.White.Opacity(0)),
+                            Width = gradient_size,
+                        },
+                        new Box
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Width = gradient_size,
+                            Colour = ColourInfo.GradientHorizontal(Color4.White.Opacity(0), Color4.White),
+                            Anchor = Anchor.TopRight,
+                            Origin = Anchor.TopRight,
+                        },
+                    }
+                },
+            };
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OsuColour color, ScoreProcessor scoreProcessor)
+        {
+            boxes.Colour = color.Red;
+
+            scoreProcessor.Combo.BindValueChanged(vce => onComboUpdated(vce.NewValue));
+        }
+
+        private void onComboUpdated(int newCombo)
+        {
+            if (newCombo < oldCombo && oldCombo >= minimum_combo_threshold && newCombo < minimum_combo_threshold)
+            {
+                // flash here
+                boxes.FadeInFromZero(50).Then().FadeOut(500, Easing.Out);
+                Logger.Log(@$"old: {oldCombo}, new: {newCombo} flashing combo break boxes!");
+            }
+
+            oldCombo = newCombo;
+        }
+    }
+}

--- a/osu.Game/Screens/Play/HUD/ComboBreakLayer.cs
+++ b/osu.Game/Screens/Play/HUD/ComboBreakLayer.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Screens.Play.HUD
         /// <summary>
         /// The minimum combo that needs to be reached before combo break overlay flashes red on combo break.
         /// </summary>
-        private const int minimum_combo_threshold = 8;
+        private const int minimum_combo_threshold = 16;
 
         private readonly Container boxes;
 
@@ -75,7 +75,8 @@ namespace osu.Game.Screens.Play.HUD
 
         private void onComboUpdated(int newCombo)
         {
-            if (newCombo < oldCombo && oldCombo >= minimum_combo_threshold && newCombo < minimum_combo_threshold)
+            // oldCombo - 1 because sometimes combo gets rewound?
+            if (newCombo < oldCombo - 1 && oldCombo >= minimum_combo_threshold && newCombo < minimum_combo_threshold)
             {
                 // flash here
                 boxes.FadeInFromZero(50).Then().FadeOut(500, Easing.Out);

--- a/osu.Game/Screens/Play/HUD/ComboBreakLayer.cs
+++ b/osu.Game/Screens/Play/HUD/ComboBreakLayer.cs
@@ -21,8 +21,8 @@ namespace osu.Game.Screens.Play.HUD
     /// </summary>
     public partial class ComboBreakLayer : CompositeDrawable
     {
-        private const float max_alpha = 0.4f;
-        private const int fade_time = 400;
+        private const float max_alpha = 0.65f;
+        private const int fade_time = 500;
         private const float gradient_size = 0.3f;
 
         /// <summary>
@@ -79,7 +79,7 @@ namespace osu.Game.Screens.Play.HUD
             if (newCombo < oldCombo - 1 && oldCombo >= minimum_combo_threshold && newCombo < minimum_combo_threshold)
             {
                 // flash here
-                boxes.FadeInFromZero(50).Then().FadeOut(500, Easing.Out);
+                boxes.FadeOut().Then().FadeTo(max_alpha, 50).Then().FadeOut(fade_time, Easing.Out);
                 Logger.Log(@$"old: {oldCombo}, new: {newCombo} flashing combo break boxes!");
             }
 

--- a/osu.Game/Screens/Play/HUDOverlay.cs
+++ b/osu.Game/Screens/Play/HUDOverlay.cs
@@ -124,6 +124,7 @@ namespace osu.Game.Screens.Play
             Children = new[]
             {
                 CreateFailingLayer(),
+                CreateComboBreakLayer(),
                 //Needs to be initialized before skinnable drawables.
                 judgementCountController = new JudgementCountController(),
                 clicksPerSecondController = new ClicksPerSecondController(),
@@ -375,6 +376,8 @@ namespace osu.Game.Screens.Play
         {
             ShowHealth = { BindTarget = ShowHealthBar }
         };
+
+        protected ComboBreakLayer CreateComboBreakLayer() => new ComboBreakLayer();
 
         protected HoldForMenuButton CreateHoldForMenuButton() => new HoldForMenuButton
         {

--- a/osu.Game/TournamentIpc/TournamentSpectatorStatisticsTracker.cs
+++ b/osu.Game/TournamentIpc/TournamentSpectatorStatisticsTracker.cs
@@ -73,10 +73,10 @@ namespace osu.Game.TournamentIpc
                     var teamScoreBindable = new BindableLong();
                     TeamScores.Add(team, teamScoreBindable);
 
-                    teamScoreBindable.BindValueChanged(vce =>
-                    {
-                        Logger.Log($"team {team} has new score: {vce.NewValue}");
-                    });
+                    // teamScoreBindable.BindValueChanged(vce =>
+                    // {
+                    //     Logger.Log($"team {team} has new score: {vce.NewValue}");
+                    // });
                 }
             }
 


### PR DESCRIPTION
Flashes screen red when player combo breaks. Minimum trigger threshold is 16 combo (not configurable at the moment)


https://github.com/user-attachments/assets/c8019bcd-0ebc-4f89-aa94-152d0a898a8e

