### PR TITLE
on-site last minute fixes

### DIFF
--- a/osu.Game.Tournament.Tests/Screens/TestSceneGameplayScreen.cs
+++ b/osu.Game.Tournament.Tests/Screens/TestSceneGameplayScreen.cs
@@ -36,6 +36,27 @@ namespace osu.Game.Tournament.Tests.Screens
         }
 
         [Test]
+        public void TestScoreDisplay()
+        {
+            AddStep("disable cumulative score", () => Ladder.CumulativeScore.Value = false);
+
+            createScreen();
+            toggleWarmup();
+
+            AddStep("set state: lobby", () => LazerIPCInfo.State.Value = TourneyState.Lobby);
+
+            AddStep("set state: playing", () => LazerIPCInfo.State.Value = TourneyState.Playing);
+            // AddStep("add score", () =>
+            // {
+            //     LazerIPCInfo.Score1.Value = 127_727;
+            //     LazerIPCInfo.Score2.Value = 63_727;
+            // });
+
+            AddSliderStep("score1 value", 0, 1_200_000, 127_727, v => LazerIPCInfo.Score1.Value = v);
+            AddSliderStep("score1 value", 0, 1_200_000, 63_727, v => LazerIPCInfo.Score2.Value = v);
+        }
+
+        [Test]
         public void TestScoreAdd()
         {
             AddStep("disable cumulative score", () => Ladder.CumulativeScore.Value = false);

--- a/osu.Game.Tournament/Screens/Gameplay/GameplayScreen.cs
+++ b/osu.Game.Tournament/Screens/Gameplay/GameplayScreen.cs
@@ -96,7 +96,7 @@ namespace osu.Game.Tournament.Screens.Gameplay
                 },
                 scoreDisplay = new TournamentMatchScoreDisplay
                 {
-                    Y = -147,
+                    Y = -170,
                     Anchor = Anchor.BottomCentre,
                     Origin = Anchor.TopCentre,
                 },
@@ -403,6 +403,7 @@ namespace osu.Game.Tournament.Screens.Gameplay
             {
                 // chroma key area for stable gameplay
                 Colour = new Color4(0, 255, 0, 255);
+                Alpha = 0.2f;
 
                 ladder.PlayersPerTeam.BindValueChanged(performLayout, true);
             }

--- a/osu.Game/Online/Chat/StandAloneChatDisplay.cs
+++ b/osu.Game/Online/Chat/StandAloneChatDisplay.cs
@@ -209,9 +209,9 @@ namespace osu.Game.Online.Chat
 
         protected partial class StandAloneMessage : ChatLine
         {
-            protected override float FontSize => 15;
-            protected override float Spacing => 5;
-            protected override float UsernameWidth => 75;
+            protected override float FontSize => 18;
+            protected override float Spacing => 4;
+            protected override float UsernameWidth => 96;
 
             public StandAloneMessage(Message message)
                 : base(message)

--- a/osu.Game/Online/Multiplayer/MultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerClient.cs
@@ -218,6 +218,7 @@ namespace osu.Game.Online.Multiplayer
                     postServerShuttingDownNotification();
 
                     OnRoomJoined();
+                    RoomUpdated?.Invoke();
                 }, cancellationSource.Token).ConfigureAwait(false);
             }, cancellationSource.Token).ConfigureAwait(false);
         }

--- a/osu.Game/Online/Spectator/SpectatorScoreProcessor.cs
+++ b/osu.Game/Online/Spectator/SpectatorScoreProcessor.cs
@@ -153,11 +153,17 @@ namespace osu.Game.Online.Spectator
             scoreInfo.MaxCombo = frame.Header.MaxCombo;
             scoreInfo.Statistics = frame.Header.Statistics;
             scoreInfo.MaximumStatistics = spectatorState.MaximumStatistics;
-            scoreInfo.TotalScore = frame.Header.TotalScore;
 
             Accuracy.Value = frame.Header.Accuracy;
             Combo.Value = frame.Header.Combo;
-            TotalScore.Value = frame.Header.TotalScore;
+
+            long newScore = frame.Header.TotalScore;
+
+            if (Mods.Any(m => m.Acronym == @"NF"))
+                newScore *= 2;
+
+            scoreInfo.TotalScore = newScore;
+            TotalScore.Value = newScore;
         }
 
         protected override void Dispose(bool isDisposing)

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -487,6 +487,9 @@ namespace osu.Game
             AddFont(Resources, @"Fonts/Venera/Venera-Bold");
             AddFont(Resources, @"Fonts/Venera/Venera-Black");
 
+            AddFont(Resources, @"Fonts/Tektur/Tektur-Regular");
+            AddFont(Resources, @"Fonts/Tektur/Tektur-Bold");
+
             Fonts.AddStore(new OsuIcon.OsuIconStore(Textures));
         }
 

--- a/osu.Game/Rulesets/Mods/ModNoFail.cs
+++ b/osu.Game/Rulesets/Mods/ModNoFail.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Rulesets.Mods
         public override IconUsage? Icon => OsuIcon.ModNoFail;
         public override ModType Type => ModType.DifficultyReduction;
         public override LocalisableString Description => "You can't fail, no matter what.";
-        public override double ScoreMultiplier => 0.5;
+        public override double ScoreMultiplier => 1.0;
         public override Type[] IncompatibleMods => new[] { typeof(ModFailCondition), typeof(ModCinema) };
         public override bool Ranked => UsesDefaultConfiguration;
 

--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -203,7 +203,12 @@ namespace osu.Game.Rulesets.Scoring
                 scoreMultiplier = 1;
 
                 foreach (var m in mods.NewValue)
+                {
+                    if (m.Acronym == @"NF")
+                        continue;
+
                     scoreMultiplier *= m.ScoreMultiplier;
+                }
 
                 updateScore();
                 updateRank();

--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -203,12 +203,7 @@ namespace osu.Game.Rulesets.Scoring
                 scoreMultiplier = 1;
 
                 foreach (var m in mods.NewValue)
-                {
-                    if (m.Acronym == @"NF")
-                        continue;
-
                     scoreMultiplier *= m.ScoreMultiplier;
-                }
 
                 updateScore();
                 updateRank();

--- a/osu.Game/Screens/OnlinePlay/Header.cs
+++ b/osu.Game/Screens/OnlinePlay/Header.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Screens.OnlinePlay
 {
     public partial class Header : Container
     {
-        public const float HEIGHT = 80;
+        public const float HEIGHT = 32;
 
         private readonly ScreenStack? stack;
         private readonly MultiHeaderTitle title;

--- a/osu.Game/Screens/OnlinePlay/Lounge/Components/RoomsContainer.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/Components/RoomsContainer.cs
@@ -168,12 +168,14 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
 
         private void updateSorting()
         {
+            const string coe_prefix = @"COE24";
+
             foreach (var room in roomFlow)
             {
-                roomFlow.SetLayoutPosition(room, room.Room.Category.Value > RoomCategory.Normal
-                    // Always show spotlight playlists at the top of the listing.
-                    ? float.MinValue
-                    : -(room.Room.RoomID.Value ?? 0));
+                roomFlow.SetLayoutPosition(room, room.Room.Category.Value > RoomCategory.Normal || room.Room.Name.Value.Contains(coe_prefix)
+                                                     // Always show spotlight playlists at the top of the listing.
+                                                     ? float.MinValue
+                                                     : -(room.Room.RoomID.Value ?? 0));
             }
         }
 

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerMatchFooter.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerMatchFooter.cs
@@ -54,8 +54,9 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
                 // in case number got clamped, reset number in numberBox
                 numberBox.Text = height.ToString();
 
+                // +64: hack!!!! COE stuff (div by 5/6 cause bruteforce at this point)
                 height = (int)(height_reduction_ratio * height);
-                windowSize.Value = new Size((int)(height * aspect_ratio), height);
+                windowSize.Value = new Size((int)(height * aspect_ratio), height + (int)(64 / (5f / 6f)));
             };
         }
 

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerMatchFooter.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerMatchFooter.cs
@@ -56,7 +56,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
 
                 // +64: hack!!!! COE stuff (div by 5/6 cause bruteforce at this point)
                 height = (int)(height_reduction_ratio * height);
-                windowSize.Value = new Size((int)(height * aspect_ratio), height + (int)(64 / (5f / 6f)));
+                windowSize.Value = new Size((int)(height * aspect_ratio), height + 64);
             };
         }
 

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
@@ -16,8 +16,10 @@ using osu.Framework.Screens;
 using osu.Framework.Threading;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
+using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Cursor;
 using osu.Game.Online;
+using osu.Game.Online.Chat;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Rooms;
 using osu.Game.Overlays;
@@ -45,6 +47,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         public override string Title { get; }
 
         public override string ShortTitle => "room";
+        private LinkFlowContainer linkFlowContainer = null!;
 
         [Resolved]
         private MultiplayerClient client { get; set; }
@@ -234,11 +237,15 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                                 RelativeSizeAxes = Axes.Both,
                                 Content = new[]
                                 {
+                                    new Drawable[] { new OverlinedHeader("Lobby ID") },
+                                    new Drawable[] { linkFlowContainer = new LinkFlowContainer { Height = 24 } },
                                     new Drawable[] { new OverlinedHeader("Chat") },
                                     new Drawable[] { new MatchChatDisplay(Room) { RelativeSizeAxes = Axes.Both } }
                                 },
                                 RowDimensions = new[]
                                 {
+                                    new Dimension(GridSizeMode.AutoSize),
+                                    new Dimension(GridSizeMode.AutoSize),
                                     new Dimension(GridSizeMode.AutoSize),
                                     new Dimension(),
                                 }
@@ -395,6 +402,12 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
             addItemButton.Alpha = localUserCanAddItem ? 1 : 0;
 
             Scheduler.AddOnce(UpdateMods);
+            Scheduler.AddOnce(() =>
+            {
+                string roomLink = $"https://{MessageFormatter.WebsiteRootUrl}/multiplayer/rooms/{Room.RoomID}";
+                linkFlowContainer.Clear();
+                linkFlowContainer.AddLink(roomLink, roomLink);
+            });
 
             Activity.Value = new UserActivity.InLobby(Room);
         }

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
@@ -123,11 +123,9 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                     RelativeSizeAxes = Axes.Both,
                     ColumnDimensions = new[]
                     {
-                        new Dimension(),
+                        new Dimension(GridSizeMode.Relative, 0.4f),
                         new Dimension(GridSizeMode.Absolute, 10),
-                        new Dimension(),
-                        new Dimension(GridSizeMode.Absolute, 10),
-                        new Dimension(),
+                        new Dimension(GridSizeMode.Relative, 0.6f),
                     },
                     Content = new[]
                     {
@@ -139,7 +137,13 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                                 RelativeSizeAxes = Axes.Both,
                                 RowDimensions = new[]
                                 {
-                                    new Dimension(GridSizeMode.AutoSize)
+                                    new Dimension(GridSizeMode.AutoSize),
+                                    new Dimension(),
+                                    new Dimension(GridSizeMode.AutoSize),
+                                    new Dimension(GridSizeMode.AutoSize),
+                                    new Dimension(GridSizeMode.Absolute, 5),
+                                    new Dimension(),
+                                    new Dimension(GridSizeMode.AutoSize),
                                 },
                                 Content = new[]
                                 {
@@ -150,17 +154,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                                         {
                                             RelativeSizeAxes = Axes.Both
                                         },
-                                    }
-                                }
-                            },
-                            // Spacer
-                            null,
-                            // Beatmap column
-                            new GridContainer
-                            {
-                                RelativeSizeAxes = Axes.Both,
-                                Content = new[]
-                                {
+                                    },
                                     new Drawable[] { new OverlinedHeader("Beatmap") },
                                     new Drawable[]
                                     {
@@ -219,14 +213,6 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                                             }
                                         },
                                     },
-                                },
-                                RowDimensions = new[]
-                                {
-                                    new Dimension(GridSizeMode.AutoSize),
-                                    new Dimension(GridSizeMode.AutoSize),
-                                    new Dimension(GridSizeMode.Absolute, 5),
-                                    new Dimension(),
-                                    new Dimension(GridSizeMode.AutoSize),
                                 }
                             },
                             // Spacer

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
@@ -238,7 +238,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                                 Content = new[]
                                 {
                                     new Drawable[] { new OverlinedHeader("Lobby ID") },
-                                    new Drawable[] { linkFlowContainer = new LinkFlowContainer { Height = 24 } },
+                                    new Drawable[] { linkFlowContainer = new LinkFlowContainer { Height = 24, AutoSizeAxes = Axes.X } },
                                     new Drawable[] { new OverlinedHeader("Chat") },
                                     new Drawable[] { new MatchChatDisplay(Room) { RelativeSizeAxes = Axes.Both } }
                                 },

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
@@ -407,6 +407,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                 string roomLink = $"https://{MessageFormatter.WebsiteRootUrl}/multiplayer/rooms/{Room.RoomID}";
                 linkFlowContainer.Clear();
                 linkFlowContainer.AddLink(roomLink, roomLink);
+                TournamentIpc?.UpdateActiveRoomId(Room.RoomID.Value ?? 0);
             });
 
             Activity.Value = new UserActivity.InLobby(Room);

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorScreen.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Logging;
@@ -15,6 +16,7 @@ using osu.Game.Online.Multiplayer.MatchTypes.TeamVersus;
 using osu.Game.Online.Rooms;
 using osu.Game.Online.Spectator;
 using osu.Game.Screens.Play;
+using osu.Game.Screens.Play.HUD;
 using osu.Game.Screens.Spectate;
 using osu.Game.TournamentIpc;
 using osu.Game.Users;
@@ -57,6 +59,9 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
         private TournamentSpectatorStatisticsTracker statisticsTracker = null!;
         private PlayerArea? currentAudioSource;
 
+        [Resolved(canBeNull: true)]
+        private TournamentFileBasedIPC? tournamentIpc { get; set; } = null!;
+
         private readonly Room room;
         private readonly MultiplayerRoomUser[] users;
 
@@ -87,7 +92,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
         private void load()
         {
             // FillFlowContainer leaderboardFlow;
-            // Container scoreDisplayContainer;
+            Container scoreDisplayContainer;
 
             InternalChildren = new Drawable[]
             {
@@ -96,17 +101,9 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
                     Child = new GridContainer
                     {
                         RelativeSizeAxes = Axes.Both,
-                        // RowDimensions = new[] { new Dimension(GridSizeMode.AutoSize) },
+                        RowDimensions = new[] { new Dimension(), new Dimension(GridSizeMode.AutoSize) },
                         Content = new[]
                         {
-                            // new Drawable[]
-                            // {
-                            //     scoreDisplayContainer = new Container
-                            //     {
-                            //         RelativeSizeAxes = Axes.X,
-                            //         AutoSizeAxes = Axes.Y
-                            //     },
-                            // },
                             new Drawable[]
                             {
                                 new GridContainer
@@ -130,7 +127,15 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
                                         }
                                     }
                                 }
-                            }
+                            },
+                            new Drawable[]
+                            {
+                                scoreDisplayContainer = new Container
+                                {
+                                    RelativeSizeAxes = Axes.X,
+                                    Height = 88 - 18,
+                                },
+                            },
                         }
                     }
                 },
@@ -170,7 +175,21 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
             //         }, scoreDisplayContainer.Add);
             //     }
             // });
-            //
+
+            int numTeams = users.Select(u => (u.MatchState as TeamVersusUserState)?.TeamID).Distinct().Count();
+
+            if (numTeams == 2)
+            {
+                LoadComponentAsync(new MatchScoreDisplay
+                {
+                    Y = -36f,
+                    Team1Score = { BindTarget = tournamentIpc?.Team1Score ?? new BindableLong() },
+                    Team2Score = { BindTarget = tournamentIpc?.Team2Score ?? new BindableLong() },
+                    RelativeSizeAxes = Axes.Y,
+                    Height = 1.0f,
+                }, scoreDisplayContainer.Add);
+            }
+
             // LoadComponentAsync(new GameplayChatDisplay(room)
             // {
             //     Expanded = { Value = true },

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorScreen.cs
@@ -176,7 +176,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
             //     }
             // });
 
-            int numTeams = users.Select(u => (u.MatchState as TeamVersusUserState)?.TeamID).Distinct().Count();
+            int numTeams = users.Count(u => u.State != MultiplayerUserState.Spectating);
 
             if (numTeams == 2)
             {

--- a/osu.Game/Screens/Play/HUD/MatchScoreDisplay.cs
+++ b/osu.Game/Screens/Play/HUD/MatchScoreDisplay.cs
@@ -11,12 +11,13 @@ using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osuTK;
+using osuTK.Graphics;
 
 namespace osu.Game.Screens.Play.HUD
 {
     public partial class MatchScoreDisplay : CompositeDrawable
     {
-        private const float bar_height = 18;
+        private const float bar_height = 24f / (5f / 6f);
         private const float font_size = 50;
 
         public BindableLong Team1Score = new BindableLong();
@@ -40,6 +41,14 @@ namespace osu.Game.Screens.Play.HUD
 
             InternalChildren = new[]
             {
+                new Box
+                {
+                    Name = "Chroma area",
+                    RelativeSizeAxes = Axes.Y,
+                    Width = 1.0f,
+                    Colour = new Color4(0, 255, 0, 255),
+                    Height = 16 * bar_height / 3, // don't ask, we're in a rush lmao
+                },
                 new Box
                 {
                     Name = "top bar red (static)",
@@ -87,7 +96,8 @@ namespace osu.Game.Screens.Play.HUD
                 new Container
                 {
                     RelativeSizeAxes = Axes.X,
-                    Height = font_size + bar_height,
+                    // Height = font_size + bar_height,
+                    Height = 105.6f, // COE hack!!!
                     Anchor = Anchor.TopCentre,
                     Origin = Anchor.TopCentre,
                     Children = new Drawable[]
@@ -110,7 +120,7 @@ namespace osu.Game.Screens.Play.HUD
                     Margin = new MarginPadding
                     {
                         Top = bar_height / 4,
-                        Horizontal = 8
+                        Horizontal = 8 + score_bar_padding_amount,
                     },
                     Alpha = 0
                 }

--- a/osu.Game/Screens/Play/HUD/MatchScoreDisplay.cs
+++ b/osu.Game/Screens/Play/HUD/MatchScoreDisplay.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Screens.Play.HUD
 
         private MatchScoreDiffCounter scoreDiffText = null!;
 
-        private const int score_bar_padding_amount = 262;
+        private const int score_bar_padding_amount = 284;
 
         [BackgroundDependencyLoader]
         private void load(OsuColour colours)

--- a/osu.Game/Screens/Play/HUD/MatchScoreDisplay.cs
+++ b/osu.Game/Screens/Play/HUD/MatchScoreDisplay.cs
@@ -44,10 +44,11 @@ namespace osu.Game.Screens.Play.HUD
                 new Box
                 {
                     Name = "Chroma area",
-                    RelativeSizeAxes = Axes.Y,
+                    RelativeSizeAxes = Axes.Both,
                     Width = 1.0f,
                     Colour = new Color4(0, 255, 0, 255),
-                    Height = 1.0f, // don't ask, we're in a rush lmao
+                    Height = 1.0f, // don't ask, we're in a rush lmao,
+                    Margin = new MarginPadding { Top = bar_height }
                 },
                 new Box
                 {

--- a/osu.Game/Screens/Play/HUD/MatchScoreDisplay.cs
+++ b/osu.Game/Screens/Play/HUD/MatchScoreDisplay.cs
@@ -30,6 +30,8 @@ namespace osu.Game.Screens.Play.HUD
 
         private MatchScoreDiffCounter scoreDiffText = null!;
 
+        private const int score_bar_padding_amount = 150;
+
         [BackgroundDependencyLoader]
         private void load(OsuColour colours)
         {
@@ -46,7 +48,8 @@ namespace osu.Game.Screens.Play.HUD
                     Width = 0.5f,
                     Colour = colours.TeamColourRed,
                     Anchor = Anchor.TopCentre,
-                    Origin = Anchor.TopRight
+                    Origin = Anchor.TopRight,
+                    Alpha = 0, // COE edit
                 },
                 new Box
                 {
@@ -56,7 +59,8 @@ namespace osu.Game.Screens.Play.HUD
                     Width = 0.5f,
                     Colour = colours.TeamColourBlue,
                     Anchor = Anchor.TopCentre,
-                    Origin = Anchor.TopLeft
+                    Origin = Anchor.TopLeft,
+                    Alpha = 0, // COE edit
                 },
                 score1Bar = new Box
                 {
@@ -66,7 +70,8 @@ namespace osu.Game.Screens.Play.HUD
                     Width = 0,
                     Colour = colours.TeamColourRed,
                     Anchor = Anchor.TopCentre,
-                    Origin = Anchor.TopRight
+                    Origin = Anchor.TopRight,
+                    Margin = new MarginPadding { Right = score_bar_padding_amount }
                 },
                 score2Bar = new Box
                 {
@@ -76,7 +81,8 @@ namespace osu.Game.Screens.Play.HUD
                     Width = 0,
                     Colour = colours.TeamColourBlue,
                     Anchor = Anchor.TopCentre,
-                    Origin = Anchor.TopLeft
+                    Origin = Anchor.TopLeft,
+                    Margin = new MarginPadding { Left = score_bar_padding_amount }
                 },
                 new Container
                 {
@@ -158,8 +164,8 @@ namespace osu.Game.Screens.Play.HUD
         protected override void UpdateAfterChildren()
         {
             base.UpdateAfterChildren();
-            Score1Text.X = -Math.Max(5 + Score1Text.DrawWidth / 2, score1Bar.DrawWidth);
-            Score2Text.X = Math.Max(5 + Score2Text.DrawWidth / 2, score2Bar.DrawWidth);
+            Score1Text.X = -Math.Max(5 + Score1Text.DrawWidth / 2, score1Bar.DrawWidth - score_bar_padding_amount / 2f) - score_bar_padding_amount;
+            Score2Text.X = Math.Max(5 + Score2Text.DrawWidth / 2, score2Bar.DrawWidth - score_bar_padding_amount / 2f) + score_bar_padding_amount;
         }
 
         protected partial class MatchScoreCounter : CommaSeparatedScoreCounter

--- a/osu.Game/Screens/Play/HUD/MatchScoreDisplay.cs
+++ b/osu.Game/Screens/Play/HUD/MatchScoreDisplay.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Screens.Play.HUD
 
         private MatchScoreDiffCounter scoreDiffText = null!;
 
-        private const int score_bar_padding_amount = 150;
+        private const int score_bar_padding_amount = 262;
 
         [BackgroundDependencyLoader]
         private void load(OsuColour colours)

--- a/osu.Game/Screens/Play/HUD/MatchScoreDisplay.cs
+++ b/osu.Game/Screens/Play/HUD/MatchScoreDisplay.cs
@@ -47,7 +47,7 @@ namespace osu.Game.Screens.Play.HUD
                     RelativeSizeAxes = Axes.Y,
                     Width = 1.0f,
                     Colour = new Color4(0, 255, 0, 255),
-                    Height = 16 * bar_height / 3, // don't ask, we're in a rush lmao
+                    Height = 1.0f, // don't ask, we're in a rush lmao
                 },
                 new Box
                 {

--- a/osu.Game/Screens/Play/HUD/MatchScoreDisplay.cs
+++ b/osu.Game/Screens/Play/HUD/MatchScoreDisplay.cs
@@ -7,6 +7,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
@@ -203,13 +204,9 @@ namespace osu.Game.Screens.Play.HUD
             private void updateFont(bool winning)
             {
                 // TODO: once font spacing is fixed
-                // displayedSpriteText.Font = winning
-                //                                ? new FontUsage("Tektur", font_size, "")
-                //                                : new FontUsage("Tektur", font_size * 0.8f, "");
-
                 displayedSpriteText.Font = winning
-                                               ? OsuFont.Torus.With(weight: FontWeight.Bold, size: font_size, fixedWidth: true)
-                                               : OsuFont.Torus.With(weight: FontWeight.Regular, size: font_size * 0.6f, fixedWidth: true);
+                                               ? new FontUsage("Tektur", font_size, FontWeight.Bold.ToString(), false, true)
+                                               : new FontUsage("Tektur", font_size * 0.6f, FontWeight.Regular.ToString(), false, true);
 
                 displayedSpriteText.Margin = new MarginPadding { Top = 4 };
             }
@@ -220,7 +217,8 @@ namespace osu.Game.Screens.Play.HUD
             protected override OsuSpriteText CreateSpriteText() => base.CreateSpriteText().With(s =>
             {
                 s.Spacing = new Vector2(-2);
-                s.Font = OsuFont.Torus.With(weight: FontWeight.Regular, size: 24, fixedWidth: true);
+                // s.Font = OsuFont.Torus.With(weight: FontWeight.Regular, size: 24, fixedWidth: true);
+                s.Font = new FontUsage("Tektur", 24, FontWeight.Regular.ToString(), false, true);
             });
         }
     }

--- a/osu.Game/Screens/Play/HUD/MatchScoreDisplay.cs
+++ b/osu.Game/Screens/Play/HUD/MatchScoreDisplay.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Screens.Play.HUD
     public partial class MatchScoreDisplay : CompositeDrawable
     {
         private const float bar_height = 24f / (5f / 6f);
-        private const float font_size = 50;
+        private const float font_size = 72;
 
         public BindableLong Team1Score = new BindableLong();
         public BindableLong Team2Score = new BindableLong();
@@ -119,7 +119,7 @@ namespace osu.Game.Screens.Play.HUD
                     Anchor = Anchor.TopCentre,
                     Margin = new MarginPadding
                     {
-                        Top = bar_height / 4,
+                        Top = 72,
                         Horizontal = 8 + score_bar_padding_amount,
                     },
                     Alpha = 0
@@ -200,9 +200,18 @@ namespace osu.Game.Screens.Play.HUD
             });
 
             private void updateFont(bool winning)
-                => displayedSpriteText.Font = winning
-                    ? OsuFont.Torus.With(weight: FontWeight.Bold, size: font_size, fixedWidth: true)
-                    : OsuFont.Torus.With(weight: FontWeight.Regular, size: font_size * 0.8f, fixedWidth: true);
+            {
+                // TODO: once font spacing is fixed
+                // displayedSpriteText.Font = winning
+                //                                ? new FontUsage("Tektur", font_size, "")
+                //                                : new FontUsage("Tektur", font_size * 0.8f, "");
+
+                displayedSpriteText.Font = winning
+                                               ? OsuFont.Torus.With(weight: FontWeight.Bold, size: font_size, fixedWidth: true)
+                                               : OsuFont.Torus.With(weight: FontWeight.Regular, size: font_size * 0.6f, fixedWidth: true);
+
+                displayedSpriteText.Margin = new MarginPadding { Top = 4 };
+            }
         }
 
         private partial class MatchScoreDiffCounter : CommaSeparatedScoreCounter
@@ -210,7 +219,7 @@ namespace osu.Game.Screens.Play.HUD
             protected override OsuSpriteText CreateSpriteText() => base.CreateSpriteText().With(s =>
             {
                 s.Spacing = new Vector2(-2);
-                s.Font = OsuFont.Torus.With(weight: FontWeight.Regular, size: bar_height, fixedWidth: true);
+                s.Font = OsuFont.Torus.With(weight: FontWeight.Regular, size: 24, fixedWidth: true);
             });
         }
     }

--- a/osu.Game/Screens/Play/HUD/MatchScoreDisplay.cs
+++ b/osu.Game/Screens/Play/HUD/MatchScoreDisplay.cs
@@ -166,7 +166,7 @@ namespace osu.Game.Screens.Play.HUD
             long diff = Math.Max(Team1Score.Value, Team2Score.Value) - Math.Min(Team1Score.Value, Team2Score.Value);
 
             losingBar.ResizeWidthTo(0, 400, Easing.OutQuint);
-            winningBar.ResizeWidthTo(Math.Min(0.4f, MathF.Pow(diff / 1500000f, 0.5f) / 2), 400, Easing.OutQuint);
+            winningBar.ResizeWidthTo(Math.Min(0.36f, MathF.Pow(diff / 1_200_000f, 0.5f) / 2), 400, Easing.OutQuint);
 
             scoreDiffText.Alpha = diff != 0 ? 1 : 0;
             scoreDiffText.Current.Value = -diff;

--- a/osu.Game/Tests/Visual/OsuTestScene.cs
+++ b/osu.Game/Tests/Visual/OsuTestScene.cs
@@ -35,6 +35,7 @@ using osu.Game.Rulesets.UI;
 using osu.Game.Storyboards;
 using osu.Game.Tests.Beatmaps;
 using osu.Game.Tests.Rulesets;
+using osu.Game.TournamentIpc;
 
 namespace osu.Game.Tests.Visual
 {
@@ -48,6 +49,9 @@ namespace osu.Game.Tests.Visual
 
         [Cached]
         protected Bindable<IReadOnlyList<Mod>> SelectedMods { get; } = new Bindable<IReadOnlyList<Mod>>(Array.Empty<Mod>());
+
+        [Cached]
+        protected TournamentFileBasedIPC TourneyIpc { get; } = new TournamentFileBasedIPC();
 
         protected new DependencyContainer Dependencies { get; private set; }
 

--- a/osu.Game/TournamentIpc/TournamentFileBasedIPC.cs
+++ b/osu.Game/TournamentIpc/TournamentFileBasedIPC.cs
@@ -4,6 +4,7 @@
 using System.Collections.Specialized;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -39,6 +40,8 @@ namespace osu.Game.TournamentIpc
         private long[] pendingScores = [];
 
         private ScheduledDelegate? flushScoresDelegate;
+
+        private Task? flushTask;
 
         // hack for COE
         private readonly BindableLong team1Score = new BindableLong();
@@ -208,7 +211,7 @@ namespace osu.Game.TournamentIpc
             }
         }
 
-        private void flushPendingScoresToDisk()
+        private void whatever()
         {
             if (pendingScores.Length == 0)
                 return;
@@ -251,6 +254,12 @@ namespace osu.Game.TournamentIpc
             {
                 // file might be busy
             }
+        }
+
+        private void flushPendingScoresToDisk()
+        {
+            if (flushTask?.IsCompleted != false)
+                flushTask = Task.Run(whatever);
         }
     }
 }

--- a/osu.Game/TournamentIpc/TournamentFileBasedIPC.cs
+++ b/osu.Game/TournamentIpc/TournamentFileBasedIPC.cs
@@ -236,11 +236,17 @@ namespace osu.Game.TournamentIpc
                         switch (idx)
                         {
                             case 0:
-                                team1Score.Value = score;
+                                Scheduler.Add(() =>
+                                {
+                                    team1Score.Value = score;
+                                });
                                 break;
 
                             case 1:
-                                team2Score.Value = score;
+                                Scheduler.Add(() =>
+                                {
+                                    team2Score.Value = score;
+                                });
                                 break;
                         }
 

--- a/osu.Game/TournamentIpc/TournamentSpectatorStatisticsTracker.cs
+++ b/osu.Game/TournamentIpc/TournamentSpectatorStatisticsTracker.cs
@@ -116,15 +116,7 @@ namespace osu.Game.TournamentIpc
         {
             if (!hasTeams)
             {
-                TournamentIpc?.UpdateTeamScores(UserScores.Values.Take(2).Select(s =>
-                {
-                    long scoreValue = s.ScoreProcessor.TotalScore.Value;
-
-                    if (s.ScoreProcessor.Mods.Any(m => m.Acronym == @"NF"))
-                        scoreValue *= 2;
-
-                    return scoreValue;
-                }).ToArray());
+                TournamentIpc?.UpdateTeamScores(UserScores.Values.Take(2).Select(s => s.ScoreProcessor.TotalScore.Value).ToArray());
                 return;
             }
 

--- a/osu.Game/TournamentIpc/TournamentSpectatorStatisticsTracker.cs
+++ b/osu.Game/TournamentIpc/TournamentSpectatorStatisticsTracker.cs
@@ -116,7 +116,15 @@ namespace osu.Game.TournamentIpc
         {
             if (!hasTeams)
             {
-                TournamentIpc?.UpdateTeamScores(UserScores.Values.Take(2).Select(s => s.ScoreProcessor.TotalScore.Value).ToArray());
+                TournamentIpc?.UpdateTeamScores(UserScores.Values.Take(2).Select(s =>
+                {
+                    long scoreValue = s.ScoreProcessor.TotalScore.Value;
+
+                    if (s.ScoreProcessor.Mods.Any(m => m.Acronym == @"NF"))
+                        scoreValue *= 2;
+
+                    return scoreValue;
+                }).ToArray());
                 return;
             }
 

--- a/osu.Game/TournamentIpc/TournamentSpectatorStatisticsTracker.cs
+++ b/osu.Game/TournamentIpc/TournamentSpectatorStatisticsTracker.cs
@@ -80,7 +80,7 @@ namespace osu.Game.TournamentIpc
                 }
             }
 
-            TournamentIpc?.UpdateTeamScores(TeamScores.Values.Select(bindableLong => bindableLong.Value).ToArray());
+            // TournamentIpc?.UpdateTeamScores(TeamScores.Values.Select(bindableLong => bindableLong.Value).ToArray());
 
             // userLookupCache.GetUsersAsync(playingUsers.Select(u => u.UserID).ToArray(), cancellationToken)
             // .ContinueWith(task =>
@@ -108,12 +108,17 @@ namespace osu.Game.TournamentIpc
             //         }
             //     });
             // }, cancellationToken);
+
+            updateTotals();
         }
 
         private void updateTotals()
         {
             if (!hasTeams)
+            {
+                TournamentIpc?.UpdateTeamScores(UserScores.Values.Take(2).Select(s => s.ScoreProcessor.TotalScore.Value).ToArray());
                 return;
+            }
 
             var teamScores = new Dictionary<int, long>();
 


### PR DESCRIPTION
- implement design from GFX to fit in with the rest of NodeCG graphics
- display scorebar with H2H rooms (players apparently hate seeing the scorebar top-left when playing TeamVS)
- visually adjust scores for broadcast when NF is used (done in TournamentIPC as well as in spectator player score processor through changing the local ModNoFail score multiplier field)
    - we require players to play with NoFail as fail scores aren't available through osu-web's API yet, but some workflows within NodeCG depend on fetching accurate scores for all maps)
    - NF applies a 0.5x multiplier to scores and that's undesirable for the audience. New viewers will wonder why the max score is 500K instead of 1M, and returning tournament viewers may incorrectly assume the players did more poorly as they actually did because they are used to NF having no multiplier with ScoreV2
- add a room link display in multiplayer room (NodeCG needs room ID to fetch scores)
- add room ID to file IPC 
- Automatically sort rooms with "COE24" so that they're always first in the rooms listing. Stage team is already under enough pressure at all times, every second counts
- Update visuals of the room lobby, making chat larger while keeping playlist items wide enough so we can see mods
    - referee can sometimes mis-apply mods so being able to see currently active mods in multiview preview lets us catch those mistakes
    - makes chat larger: our multiview TV didn't arrive so we only had a large monitor. reading chat off the multiview was hard with the default chat and font size
- move score IPC to run on its own thread. running file IO on osu's update thread was OK in testing, but the broadcast PC was already overloaded and file IO became extremely slow, sometimes causing visible stutters during gameplay. 