### PR TITLE
add support for team-based tournaments to use Head-to-Head lobby

### DIFF
--- a/.run/osu! (Second Client).run.xml
+++ b/.run/osu! (Second Client).run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="osu! (Second Client)" type="DotNetProject" factoryName=".NET Project" folderName="osu!" activateToolWindowBeforeRun="false">
-    <option name="EXE_PATH" value="$PROJECT_DIR$/osu.Desktop/bin/Debug/net8.0/osu!.dll" />
+    <option name="EXE_PATH" value="$PROJECT_DIR$/osu.Desktop/bin/Debug/net8.0/osu!" />
     <option name="PROGRAM_PARAMETERS" value="--debug-client-id=1" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/osu.Desktop/bin/Debug/net8.0" />
     <option name="PASS_PARENT_ENVS" value="1" />

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -223,6 +223,7 @@ namespace osu.Game.Configuration
 
             SetDefault(OsuSetting.EditorSubmissionNotifyOnDiscussionReplies, true);
             SetDefault(OsuSetting.EditorSubmissionLoadInBrowserAfterSubmission, true);
+            SetDefault(OsuSetting.SynthetizeTeamsInHeadToHead, true); // easier to default to true for tclient purposes
         }
 
         protected override bool CheckLookupContainsPrivateInformation(OsuSetting lookup)
@@ -469,5 +470,6 @@ namespace osu.Game.Configuration
         EditorShowStoryboard,
         EditorSubmissionNotifyOnDiscussionReplies,
         EditorSubmissionLoadInBrowserAfterSubmission,
+        SynthetizeTeamsInHeadToHead
     }
 }

--- a/osu.Game/Online/Multiplayer/MultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerClient.cs
@@ -368,6 +368,20 @@ namespace osu.Game.Online.Multiplayer
             }
         }
 
+        public bool MoveUserSlot(MultiplayerRoomUser user, int newSlot)
+        {
+            if (Room == null)
+            {
+                return false;
+            }
+
+            Room.Users.Remove(user);
+            Room.Users.Insert(newSlot, user);
+
+            RoomUpdated?.Invoke();
+            return true;
+        }
+
         /// <summary>
         /// Toggles the <see cref="LocalUser"/>'s spectating state.
         /// </summary>

--- a/osu.Game/Screens/OnlinePlay/Match/RoomSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Match/RoomSubScreen.cs
@@ -17,6 +17,7 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Screens;
 using osu.Game.Audio;
 using osu.Game.Beatmaps;
+using osu.Game.Configuration;
 using osu.Game.Graphics.Cursor;
 using osu.Game.Online.API;
 using osu.Game.Online.Rooms;
@@ -78,6 +79,9 @@ namespace osu.Game.Screens.OnlinePlay.Match
 
         [Resolved]
         private BeatmapManager beatmapManager { get; set; } = null!;
+
+        [Resolved]
+        protected OsuConfigManager ConfigManager { get; private set; } = null!;
 
         [Resolved]
         protected RulesetStore Rulesets { get; private set; } = null!;

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
@@ -468,7 +468,8 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
             Debug.Assert(client.LocalUser != null);
             Debug.Assert(client.Room != null);
 
-            int[] userIds = client.CurrentMatchPlayingUserIds.ToArray();
+            // force using room Users order when collecting players
+            int[] userIds = client.Room.Users.Where(u => u.State >= MultiplayerUserState.WaitingForLoad && u.State <= MultiplayerUserState.FinishedPlay).Select(u => u.UserID).ToArray();
             MultiplayerRoomUser[] users = userIds.Select(id => client.Room.Users.First(u => u.UserID == id)).ToArray();
 
             switch (client.LocalUser.State)

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
@@ -22,6 +22,7 @@ using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Rooms;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Dialog;
+using osu.Game.Overlays.Settings;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Screens.OnlinePlay.Components;
@@ -235,12 +236,21 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                                 Content = new[]
                                 {
                                     new Drawable[] { new OverlinedHeader("Chat") },
-                                    new Drawable[] { new MatchChatDisplay(Room) { RelativeSizeAxes = Axes.Both } }
+                                    new Drawable[] { new MatchChatDisplay(Room) { RelativeSizeAxes = Axes.Both } },
+                                    new Drawable[]
+                                    {
+                                        new SettingsCheckbox
+                                        {
+                                            LabelText = @"Assume teams using player slots",
+                                            Current = ConfigManager.GetBindable<bool>(OsuSetting.SynthetizeTeamsInHeadToHead)
+                                        },
+                                    }
                                 },
                                 RowDimensions = new[]
                                 {
                                     new Dimension(GridSizeMode.AutoSize),
                                     new Dimension(),
+                                    new Dimension(GridSizeMode.AutoSize),
                                 }
                             },
                         }

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantPanel.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantPanel.cs
@@ -82,6 +82,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
                     new Dimension(GridSizeMode.AutoSize),
                     new Dimension(),
                     new Dimension(GridSizeMode.AutoSize),
+                    new Dimension(GridSizeMode.AutoSize),
                 },
                 Content = new[]
                 {
@@ -200,6 +201,12 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
                             Margin = new MarginPadding(4),
                             Action = () => client.KickUser(User.UserID).FireAndForget(),
                         },
+                        new ReorderArrowButtons
+                        {
+                            Anchor = Anchor.CentreLeft,
+                            Origin = Anchor.CentreLeft,
+                            Margin = new MarginPadding { Vertical = 0, Horizontal = 4 },
+                        },
                     },
                 }
             };
@@ -317,6 +324,71 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
             private void load(OsuColour colours)
             {
                 IconHoverColour = colours.Red;
+            }
+        }
+
+        public partial class ReorderButton : IconButton
+        {
+            public ReorderButton(bool directionDown)
+            {
+                Icon = directionDown ? FontAwesome.Solid.ArrowDown : FontAwesome.Solid.ArrowUp;
+                TooltipText = $@"Move {(directionDown ? @"down" : @"up")}";
+                RelativeSizeAxes = Axes.None;
+            }
+
+            [BackgroundDependencyLoader]
+            private void load(OsuColour colours)
+            {
+                IconHoverColour = colours.Green;
+            }
+        }
+
+        private partial class ReorderArrowButtons : CompositeComponent
+        {
+            private ReorderButton buttonUp = null!;
+            private ReorderButton buttonDown = null!;
+
+            public ReorderArrowButtons()
+            {
+                Size = new Vector2(IconButton.DEFAULT_BUTTON_SIZE);
+            }
+
+            [BackgroundDependencyLoader]
+            private void load()
+            {
+                InternalChild = new GridContainer
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    RowDimensions = new[]
+                    {
+                        new Dimension(),
+                        new Dimension(),
+                    },
+                    Content = new[]
+                    {
+                        new Drawable[]
+                        {
+                            buttonUp = new ReorderButton(false)
+                            {
+                                RelativeSizeAxes = Axes.X,
+                                Height = Size.Y / 2,
+                                Width = 1.0f
+                            }
+                        },
+                        new Drawable[]
+                        {
+                            buttonDown = new ReorderButton(true)
+                            {
+                                RelativeSizeAxes = Axes.X,
+                                Height = Size.Y / 2,
+                                Width = 1.0f
+                            }
+                        }
+                    }
+                };
+
+                buttonUp.IconScale = new Vector2(1, 0.5f);
+                buttonDown.IconScale = new Vector2(1, 0.5f);
             }
         }
 


### PR DESCRIPTION
- add ability to reorder players locally
- calculate team scores based on player slot positions (1st half are red, 2nd half are blue, number of players **must be even**)
