### PR TITLE
use square flags

### DIFF
--- a/osu.Game.Tournament/Components/DrawableTeamFlag.cs
+++ b/osu.Game.Tournament/Components/DrawableTeamFlag.cs
@@ -33,7 +33,7 @@ namespace osu.Game.Tournament.Components
         {
             if (team == null) return;
 
-            Size = new Vector2(75, 54);
+            Size = new Vector2(68);
             Masking = true;
             CornerRadius = 5;
             Children = new Drawable[]

--- a/osu.Game.Tournament/Components/DrawableTeamFlag.cs
+++ b/osu.Game.Tournament/Components/DrawableTeamFlag.cs
@@ -6,7 +6,6 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
 using osu.Game.Tournament.Models;
@@ -38,11 +37,6 @@ namespace osu.Game.Tournament.Components
             CornerRadius = 5;
             Children = new Drawable[]
             {
-                new Box
-                {
-                    RelativeSizeAxes = Axes.Both,
-                    Colour = Colour4.FromHex("333"),
-                },
                 flagSprite = new Sprite
                 {
                     RelativeSizeAxes = Axes.Both,


### PR DESCRIPTION
also removes gray background when flag image has transparency

|Before|After|
|---|---|
|<video src="https://github.com/user-attachments/assets/95d9512f-daf5-4563-bd12-e7ed8e8c9217">|<video src="https://github.com/user-attachments/assets/32f863f8-5411-44b8-ae46-e46394ffd479">|


With transparency:

https://github.com/user-attachments/assets/1c00b47b-ca4d-4e0f-a27c-10cfdda64b25

