### PR TITLE
Add better showcase capabilities to tourney client (pool slots, offline maps)

### DIFF
--- a/osu.Game.Tournament/Components/SongBar.cs
+++ b/osu.Game.Tournament/Components/SongBar.cs
@@ -32,6 +32,8 @@ namespace osu.Game.Tournament.Components
         private IBeatmapInfo? oldBeatmap;
         private bool beatmapChanged = false;
 
+        private TournamentBeatmapPanel beatmapPanel = null!;
+
         private DiffPiece diffPiece1 = null!;
         private DiffPiece diffPiece2 = null!;
         private DiffPiece diffPiece3 = null!;
@@ -230,7 +232,7 @@ namespace osu.Game.Tournament.Components
                                 }
                             }
                         },
-                        new TournamentBeatmapPanel(beatmap)
+                        beatmapPanel = new TournamentBeatmapPanel(beatmap)
                         {
                             RelativeSizeAxes = Axes.X,
                             Width = 0.5f,
@@ -247,6 +249,8 @@ namespace osu.Game.Tournament.Components
 
         private void refreshContent()
         {
+            flow.Remove(beatmapPanel, true);
+
             beatmap ??= new BeatmapInfo
             {
                 Metadata = new BeatmapMetadata
@@ -266,6 +270,15 @@ namespace osu.Game.Tournament.Components
                     ApproachRate = 0,
                 },
             };
+
+            flow.Add(beatmapPanel = new TournamentBeatmapPanel(beatmap)
+            {
+                RelativeSizeAxes = Axes.X,
+                Width = 0.5f,
+                Height = HEIGHT,
+                Anchor = Anchor.BottomRight,
+                Origin = Anchor.BottomRight,
+            });
 
             double bpm = beatmap.BPM;
             double length = beatmap.Length;

--- a/osu.Game.Tournament/Components/SongBar.cs
+++ b/osu.Game.Tournament/Components/SongBar.cs
@@ -74,7 +74,8 @@ namespace osu.Game.Tournament.Components
             }
         }
 
-        private readonly Dictionary<int, string> poolSlotsText = new Dictionary<int, string>();
+        // private readonly Dictionary<int, string> poolSlotsText = new Dictionary<int, string>();
+        private readonly Dictionary<(int, string), string> poolSlotsText = new Dictionary<(int, string), string>();
 
         public List<RoundBeatmap> Pool
         {
@@ -93,7 +94,7 @@ namespace osu.Game.Tournament.Components
                         modSlotIndex = 1;
                     }
 
-                    poolSlotsText[b.ID] = currentMods == "TB" ? currentMods : $"{currentMods}{modSlotIndex}";
+                    poolSlotsText[(b.ID, b.MD5)] = currentMods == "TB" ? currentMods : $"{currentMods}{modSlotIndex}";
                     modSlotIndex++;
                 }
 
@@ -353,8 +354,10 @@ namespace osu.Game.Tournament.Components
 
             FillFlowContainer<GlowingSpriteText>? currentFlow = null;
 
-            foreach (int mapId in poolSlotsText.Keys)
+            foreach (var key in poolSlotsText.Keys)
             {
+                (int mapId, string md5) = key;
+
                 if (currentFlow == null || currentFlow.Children.Count > newlineThreshold)
                 {
                     currentFlow = new FillFlowContainer<GlowingSpriteText>
@@ -370,13 +373,13 @@ namespace osu.Game.Tournament.Components
 
                 var glowText = new GlowingSpriteText
                 {
-                    Text = poolSlotsText[mapId],
+                    Text = poolSlotsText[key],
                     Font = OsuFont.GetFont(weight: FontWeight.SemiBold),
                     GlowColour = Color4Extensions.FromHex("#FFFFFF").Opacity(0.2f),
                 };
                 currentFlow.Add(glowText);
 
-                if (mapId == beatmap?.OnlineID)
+                if ((mapId != -1 && mapId == beatmap?.OnlineID) || md5 == beatmap?.MD5Hash)
                 {
                     glowText.TransformTo(nameof(glowText.GlowColour), (ColourInfo)Color4Extensions.FromHex("#fff8e5"), slot_text_duration);
                     glowText.TransformTo(nameof(glowText.Colour), (ColourInfo)Color4Extensions.FromHex("#faf79f"), slot_text_duration);
@@ -384,7 +387,7 @@ namespace osu.Game.Tournament.Components
 
                 if (beatmapChanged)
                 {
-                    if (mapId == oldBeatmap?.OnlineID)
+                    if ((mapId != -1 && mapId == oldBeatmap?.OnlineID) || md5 == oldBeatmap?.MD5Hash)
                     {
                         glowText.GlowColour = Color4Extensions.FromHex("#fff8e5");
                         glowText.Colour = Color4Extensions.FromHex("#faf79f");

--- a/osu.Game.Tournament/Components/SongBar.cs
+++ b/osu.Game.Tournament/Components/SongBar.cs
@@ -32,6 +32,11 @@ namespace osu.Game.Tournament.Components
         private IBeatmapInfo? oldBeatmap;
         private bool beatmapChanged = false;
 
+        private DiffPiece diffPiece1 = null!;
+        private DiffPiece diffPiece2 = null!;
+        private DiffPiece diffPiece3 = null!;
+        private DiffPiece diffPiece4 = null!;
+
         public const float HEIGHT = 145 / 2f;
         private const int slot_text_duration = 400;
 
@@ -94,7 +99,7 @@ namespace osu.Game.Tournament.Components
         }
 
         private FillFlowContainer flow = null!;
-        private FillFlowContainer<FillFlowContainer<GlowingSpriteText>>? poolSlots;
+        private FillFlowContainer<FillFlowContainer<GlowingSpriteText>> poolSlots = null!;
 
         private bool expanded;
 
@@ -135,6 +140,105 @@ namespace osu.Game.Tournament.Components
                     Direction = FillDirection.Full,
                     Anchor = Anchor.BottomRight,
                     Origin = Anchor.BottomRight,
+
+                    Children = new Drawable[]
+                    {
+                        new Container
+                        {
+                            RelativeSizeAxes = Axes.X,
+                            Height = HEIGHT,
+                            Width = 0.5f,
+                            Anchor = Anchor.BottomRight,
+                            Origin = Anchor.BottomRight,
+
+                            Children = new Drawable[]
+                            {
+                                new GridContainer
+                                {
+                                    RelativeSizeAxes = Axes.Both,
+
+                                    ColumnDimensions = new[]
+                                    {
+                                        new Dimension(),
+                                        new Dimension(),
+                                        new Dimension(GridSizeMode.AutoSize),
+                                        new Dimension(GridSizeMode.Absolute, size: HEIGHT)
+                                    },
+
+                                    Content = new[]
+                                    {
+                                        new Drawable[]
+                                        {
+                                            new FillFlowContainer
+                                            {
+                                                RelativeSizeAxes = Axes.X,
+                                                AutoSizeAxes = Axes.Y,
+                                                Anchor = Anchor.Centre,
+                                                Origin = Anchor.Centre,
+                                                Direction = FillDirection.Vertical,
+                                                Children = new Drawable[]
+                                                {
+                                                    diffPiece1 = new DiffPiece(),
+                                                    diffPiece2 = new DiffPiece()
+                                                }
+                                            },
+                                            new FillFlowContainer
+                                            {
+                                                RelativeSizeAxes = Axes.X,
+                                                AutoSizeAxes = Axes.Y,
+                                                Anchor = Anchor.Centre,
+                                                Origin = Anchor.Centre,
+                                                Direction = FillDirection.Vertical,
+                                                Children = new Drawable[]
+                                                {
+                                                    diffPiece3 = new DiffPiece(),
+                                                    diffPiece4 = new DiffPiece(),
+                                                }
+                                            },
+                                            poolSlots = new FillFlowContainer<FillFlowContainer<GlowingSpriteText>>
+                                            {
+                                                AutoSizeAxes = Axes.Both,
+                                                Anchor = Anchor.Centre,
+                                                Origin = Anchor.Centre,
+                                                Direction = FillDirection.Vertical,
+                                                Margin = new MarginPadding { Horizontal = 16 },
+                                            },
+                                            new Container
+                                            {
+                                                RelativeSizeAxes = Axes.Both,
+                                                Children = new Drawable[]
+                                                {
+                                                    new Box
+                                                    {
+                                                        Colour = Color4.Black,
+                                                        RelativeSizeAxes = Axes.Both,
+                                                        Alpha = 0.1f,
+                                                    },
+                                                    new OsuLogo
+                                                    {
+                                                        Triangles = false,
+                                                        Scale = new Vector2(0.08f),
+                                                        Margin = new MarginPadding(50),
+                                                        X = -10,
+                                                        Anchor = Anchor.CentreRight,
+                                                        Origin = Anchor.CentreRight,
+                                                    },
+                                                }
+                                            },
+                                        },
+                                    }
+                                }
+                            }
+                        },
+                        new TournamentBeatmapPanel(beatmap)
+                        {
+                            RelativeSizeAxes = Axes.X,
+                            Width = 0.5f,
+                            Height = HEIGHT,
+                            Anchor = Anchor.BottomRight,
+                            Origin = Anchor.BottomRight,
+                        }
+                    },
                 }
             };
 
@@ -218,104 +322,13 @@ namespace osu.Game.Tournament.Components
                     break;
             }
 
-            flow.Children = new Drawable[]
-            {
-                new Container
-                {
-                    RelativeSizeAxes = Axes.X,
-                    Height = HEIGHT,
-                    Width = 0.5f,
-                    Anchor = Anchor.BottomRight,
-                    Origin = Anchor.BottomRight,
+            diffPiece1.Stats = stats;
+            diffPiece2.Stats = [("Star Rating", $"{beatmap.StarRating.FormatStarRating()}{srExtra}")];
+            diffPiece3.Stats = [("Length", length.ToFormattedDuration().ToString())];
+            diffPiece4.Stats = [("BPM", $"{bpm:0.#}")];
 
-                    Children = new Drawable[]
-                    {
-                        new GridContainer
-                        {
-                            RelativeSizeAxes = Axes.Both,
-
-                            ColumnDimensions = new[]
-                            {
-                                new Dimension(),
-                                new Dimension(),
-                                new Dimension(GridSizeMode.AutoSize),
-                                new Dimension(GridSizeMode.Absolute, size: HEIGHT)
-                            },
-
-                            Content = new[]
-                            {
-                                new Drawable[]
-                                {
-                                    new FillFlowContainer
-                                    {
-                                        RelativeSizeAxes = Axes.X,
-                                        AutoSizeAxes = Axes.Y,
-                                        Anchor = Anchor.Centre,
-                                        Origin = Anchor.Centre,
-                                        Direction = FillDirection.Vertical,
-                                        Children = new Drawable[]
-                                        {
-                                            new DiffPiece(stats),
-                                            new DiffPiece(("Star Rating", $"{beatmap.StarRating.FormatStarRating()}{srExtra}"))
-                                        }
-                                    },
-                                    new FillFlowContainer
-                                    {
-                                        RelativeSizeAxes = Axes.X,
-                                        AutoSizeAxes = Axes.Y,
-                                        Anchor = Anchor.Centre,
-                                        Origin = Anchor.Centre,
-                                        Direction = FillDirection.Vertical,
-                                        Children = new Drawable[]
-                                        {
-                                            new DiffPiece(("Length", length.ToFormattedDuration().ToString())),
-                                            new DiffPiece(("BPM", $"{bpm:0.#}")),
-                                        }
-                                    },
-                                    poolSlots = new FillFlowContainer<FillFlowContainer<GlowingSpriteText>>
-                                    {
-                                        AutoSizeAxes = Axes.Both,
-                                        Anchor = Anchor.Centre,
-                                        Origin = Anchor.Centre,
-                                        Direction = FillDirection.Vertical,
-                                        Margin = new MarginPadding { Horizontal = 16 },
-                                    },
-                                    new Container
-                                    {
-                                        RelativeSizeAxes = Axes.Both,
-                                        Children = new Drawable[]
-                                        {
-                                            new Box
-                                            {
-                                                Colour = Color4.Black,
-                                                RelativeSizeAxes = Axes.Both,
-                                                Alpha = 0.1f,
-                                            },
-                                            new OsuLogo
-                                            {
-                                                Triangles = false,
-                                                Scale = new Vector2(0.08f),
-                                                Margin = new MarginPadding(50),
-                                                X = -10,
-                                                Anchor = Anchor.CentreRight,
-                                                Origin = Anchor.CentreRight,
-                                            },
-                                        }
-                                    },
-                                },
-                            }
-                        }
-                    }
-                },
-                new TournamentBeatmapPanel(beatmap)
-                {
-                    RelativeSizeAxes = Axes.X,
-                    Width = 0.5f,
-                    Height = HEIGHT,
-                    Anchor = Anchor.BottomRight,
-                    Origin = Anchor.BottomRight,
-                }
-            };
+            // update mod slots display
+            poolSlots.Clear();
 
             int newlineThreshold = 0;
 
@@ -372,19 +385,39 @@ namespace osu.Game.Tournament.Components
 
         public partial class DiffPiece : TextFlowContainer
         {
-            public DiffPiece(params (string heading, string content)[] tuples)
+            private (string heading, string content)[] statsParts = [];
+
+            public (string heading, string content)[] Stats
+            {
+                get => statsParts;
+                set
+                {
+                    if (statsParts == value)
+                        return;
+
+                    statsParts = value;
+                    redrawText();
+                }
+            }
+
+            public DiffPiece()
             {
                 Margin = new MarginPadding { Horizontal = 15, Vertical = 1 };
                 AutoSizeAxes = Axes.Both;
+            }
 
-                static void cp(SpriteText s, bool bold)
-                {
-                    s.Font = OsuFont.Torus.With(weight: bold ? FontWeight.Bold : FontWeight.Regular, size: 15);
-                }
+            private static void cp(SpriteText s, bool bold)
+            {
+                s.Font = OsuFont.Torus.With(weight: bold ? FontWeight.Bold : FontWeight.Regular, size: 15);
+            }
 
-                for (int i = 0; i < tuples.Length; i++)
+            private void redrawText()
+            {
+                Clear();
+
+                for (int i = 0; i < statsParts.Length; i++)
                 {
-                    (string heading, string content) = tuples[i];
+                    (string heading, string content) = statsParts[i];
 
                     if (i > 0)
                     {
@@ -399,6 +432,13 @@ namespace osu.Game.Tournament.Components
                     AddText(" ", s => cp(s, false));
                     AddText(new TournamentSpriteText { Text = content }, s => cp(s, true));
                 }
+            }
+
+            protected override void LoadComplete()
+            {
+                base.LoadComplete();
+
+                redrawText();
             }
         }
     }

--- a/osu.Game.Tournament/Components/SongBar.cs
+++ b/osu.Game.Tournament/Components/SongBar.cs
@@ -343,7 +343,11 @@ namespace osu.Game.Tournament.Components
             diffPiece4.Stats = [("BPM", $"{bpm:0.#}")];
 
             // update mod slots display
+            updateSlotDisplay();
+        }
 
+        private void updateSlotDisplay()
+        {
             // a little workaround to handle having beatmap being updated (to update background image IPC) without actually changing beaatmap
             {
                 bool isSameBeatmap = false;
@@ -356,15 +360,12 @@ namespace osu.Game.Tournament.Components
                     isSameBeatmap = true;
                 }
 
-                // Check if the beatmap has the same MD5 hash as the old beatmap
-                // and ensure the MD5 hash is not null or empty
+                // Check if the beatmap has the same MD5 hash as the old beatmap and ensure the MD5 hash is not null or empty
                 else if (beatmap?.MD5Hash == oldBeatmap?.MD5Hash &&
                          !string.IsNullOrEmpty(beatmap?.MD5Hash))
                 {
                     isSameBeatmap = true;
                 }
-
-                // Use isSameBeatmap for further logic
 
                 if (isSameBeatmap)
                 {
@@ -415,6 +416,7 @@ namespace osu.Game.Tournament.Components
                     glowText.TransformTo(nameof(glowText.Colour), (ColourInfo)Color4Extensions.FromHex("#faf79f"), slot_text_duration);
                 }
 
+                // move glow to new slot
                 if (beatmapChanged)
                 {
                     if ((mapId != -1 && mapId == oldBeatmap?.OnlineID) || md5 == oldBeatmap?.MD5Hash)

--- a/osu.Game.Tournament/Components/SongBar.cs
+++ b/osu.Game.Tournament/Components/SongBar.cs
@@ -343,6 +343,36 @@ namespace osu.Game.Tournament.Components
             diffPiece4.Stats = [("BPM", $"{bpm:0.#}")];
 
             // update mod slots display
+
+            // a little workaround to handle having beatmap being updated (to update background image IPC) without actually changing beaatmap
+            {
+                bool isSameBeatmap = false;
+
+                // Check if the beatmap has a valid OnlineID and if it matches the old beatmap's OnlineID
+                if (beatmap?.OnlineID != -1 &&
+                    beatmap?.OnlineID != null &&
+                    beatmap?.OnlineID == oldBeatmap?.OnlineID)
+                {
+                    isSameBeatmap = true;
+                }
+
+                // Check if the beatmap has the same MD5 hash as the old beatmap
+                // and ensure the MD5 hash is not null or empty
+                else if (beatmap?.MD5Hash == oldBeatmap?.MD5Hash &&
+                         !string.IsNullOrEmpty(beatmap?.MD5Hash))
+                {
+                    isSameBeatmap = true;
+                }
+
+                // Use isSameBeatmap for further logic
+
+                if (isSameBeatmap)
+                {
+                    beatmapChanged = false;
+                    return;
+                }
+            }
+
             poolSlots.Clear();
 
             int newlineThreshold = 0;

--- a/osu.Game.Tournament/Components/SongBar.cs
+++ b/osu.Game.Tournament/Components/SongBar.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -347,7 +348,7 @@ namespace osu.Game.Tournament.Components
 
             if (poolSlotsText.Count > 2)
             {
-                newlineThreshold = poolSlotsText.Count / 2;
+                newlineThreshold = Math.Max(4, poolSlotsText.Count / 2);
             }
 
             FillFlowContainer<GlowingSpriteText>? currentFlow = null;

--- a/osu.Game.Tournament/Components/SongBar.cs
+++ b/osu.Game.Tournament/Components/SongBar.cs
@@ -40,7 +40,7 @@ namespace osu.Game.Tournament.Components
         private DiffPiece diffPiece4 = null!;
 
         public const float HEIGHT = 145 / 2f;
-        private const int slot_text_duration = 400;
+        private const int slot_text_duration = 250;
 
         [Resolved]
         private IBindable<RulesetInfo> ruleset { get; set; } = null!;
@@ -377,8 +377,8 @@ namespace osu.Game.Tournament.Components
 
                 if (mapId == beatmap?.OnlineID)
                 {
-                    glowText.Delay(slot_text_duration).Then().TransformTo(nameof(glowText.GlowColour), (ColourInfo)Color4Extensions.FromHex("#fff8e5"), slot_text_duration);
-                    glowText.Delay(slot_text_duration).Then().TransformTo(nameof(glowText.Colour), (ColourInfo)Color4Extensions.FromHex("#faf79f"), slot_text_duration);
+                    glowText.TransformTo(nameof(glowText.GlowColour), (ColourInfo)Color4Extensions.FromHex("#fff8e5"), slot_text_duration);
+                    glowText.TransformTo(nameof(glowText.Colour), (ColourInfo)Color4Extensions.FromHex("#faf79f"), slot_text_duration);
                 }
 
                 if (beatmapChanged)
@@ -387,8 +387,8 @@ namespace osu.Game.Tournament.Components
                     {
                         glowText.GlowColour = Color4Extensions.FromHex("#fff8e5");
                         glowText.Colour = Color4Extensions.FromHex("#faf79f");
-                        glowText.Delay(slot_text_duration).Then().TransformTo(nameof(glowText.GlowColour), (ColourInfo)Color4Extensions.FromHex("#FFFFFF").Opacity(0.2f), slot_text_duration);
-                        glowText.Delay(slot_text_duration).Then().TransformTo(nameof(glowText.Colour), (ColourInfo)Color4Extensions.FromHex("#FFFFFF"), slot_text_duration);
+                        glowText.TransformTo(nameof(glowText.GlowColour), (ColourInfo)Color4Extensions.FromHex("#FFFFFF").Opacity(0.2f), slot_text_duration);
+                        glowText.TransformTo(nameof(glowText.Colour), (ColourInfo)Color4Extensions.FromHex("#FFFFFF"), slot_text_duration);
                     }
                 }
             }

--- a/osu.Game.Tournament/IPC/FileBasedIPC.cs
+++ b/osu.Game.Tournament/IPC/FileBasedIPC.cs
@@ -11,6 +11,8 @@ using osu.Framework.Graphics;
 using osu.Framework.Logging;
 using osu.Framework.Platform;
 using osu.Framework.Threading;
+using osu.Game.Beatmaps;
+using osu.Game.IO.Serialization;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests;
 using osu.Game.Online.API.Requests.Responses;
@@ -70,17 +72,28 @@ namespace osu.Game.Tournament.IPC
                     // beatmap
                     try
                     {
+                        int beatmapId;
+
                         using (var stream = IPCStorage.GetStream(IpcFiles.BEATMAP))
                         using (var sr = new StreamReader(stream))
                         {
-                            int beatmapId = int.Parse(sr.ReadLine().AsNonNull());
+                            beatmapId = int.Parse(sr.ReadLine().AsNonNull());
+                        }
 
-                            if (lastBeatmapId != beatmapId)
+                        if (lastBeatmapId != beatmapId)
+                        {
+                            lastBeatmapId = beatmapId;
+
+                            // id of -1: unsubmitted map
+                            if (beatmapId == -1)
+                            {
+                                Logger.Log($"Hello, i got a -1 beatmap id. wtf man?");
+
+                                // var existing = ladder.CurrentMatch.Value?.Round.Value?.Beatmaps.FirstOrDefault(b => b.MD5 == );
+                            }
+                            else
                             {
                                 beatmapLookupRequest?.Cancel();
-
-                                lastBeatmapId = beatmapId;
-
                                 var existing = ladder
                                                .CurrentMatch.Value
                                                ?.Round.Value
@@ -97,15 +110,40 @@ namespace osu.Game.Tournament.IPC
                                         if (lastBeatmapId == beatmapId)
                                             Beatmap.Value = new TournamentBeatmap(b);
                                     };
-                                    beatmapLookupRequest.Failure += _ =>
-                                    {
-                                        if (lastBeatmapId == beatmapId)
-                                            Beatmap.Value = null;
-                                    };
+                                    // beatmapLookupRequest.Failure += _ =>
+                                    // {
+                                    //     if (lastBeatmapId == beatmapId)
+                                    //         Beatmap.Value = null;
+                                    // };
                                     API.Queue(beatmapLookupRequest);
                                 }
                             }
                         }
+                    }
+                    catch
+                    {
+                        // file might be in use
+                    }
+
+                    // beatmap metadata (lookup via MD5 instead of API)
+                    try
+                    {
+                        if (lastBeatmapId != -1)
+                            return;
+
+                        BeatmapInfo beatmapInfo;
+
+                        using (var stream = IPCStorage.GetStream(IpcFiles.BEATMAP_METADATA))
+                        using (var sr = new StreamReader(stream))
+                        {
+                            beatmapInfo = sr.ReadToEnd().Deserialize<BeatmapInfo>();
+                        }
+
+                        if (beatmapInfo == null)
+                            return;
+
+                        if (Beatmap.Value?.MD5Hash != beatmapInfo.MD5Hash)
+                            Beatmap.Value = new TournamentBeatmap(beatmapInfo);
                     }
                     catch
                     {

--- a/osu.Game.Tournament/IPC/FileBasedIPC.cs
+++ b/osu.Game.Tournament/IPC/FileBasedIPC.cs
@@ -55,6 +55,8 @@ namespace osu.Game.Tournament.IPC
         private LadderInfo ladder { get; set; } = null!;
 
         private int lastBeatmapId;
+
+        // ReSharper disable once NotAccessedField.Local
         private ScheduledDelegate? scheduled;
         private GetBeatmapRequest? beatmapLookupRequest;
 
@@ -85,13 +87,7 @@ namespace osu.Game.Tournament.IPC
                             lastBeatmapId = beatmapId;
 
                             // id of -1: unsubmitted map
-                            if (beatmapId == -1)
-                            {
-                                Logger.Log($"Hello, i got a -1 beatmap id. wtf man?");
-
-                                // var existing = ladder.CurrentMatch.Value?.Round.Value?.Beatmaps.FirstOrDefault(b => b.MD5 == );
-                            }
-                            else
+                            if (beatmapId != -1)
                             {
                                 beatmapLookupRequest?.Cancel();
                                 var existing = ladder
@@ -143,7 +139,7 @@ namespace osu.Game.Tournament.IPC
                             return;
 
                         if (Beatmap.Value?.MD5Hash != beatmapInfo.MD5Hash)
-                            Beatmap.Value = new TournamentBeatmap(beatmapInfo);
+                            Beatmap.Value = new TournamentBeatmap(beatmapInfo, new BeatmapSetOnlineCovers { Cover = IpcFiles.BEATMAP_BACKGROUND });
                     }
                     catch
                     {
@@ -223,7 +219,6 @@ namespace osu.Game.Tournament.IPC
                     }
                     catch
                     {
-                        Logger.Log($"couldnt read ipc");
                         // file might be busy
                     }
                 }, 250, true);

--- a/osu.Game.Tournament/IPC/FileBasedIPC.cs
+++ b/osu.Game.Tournament/IPC/FileBasedIPC.cs
@@ -61,8 +61,7 @@ namespace osu.Game.Tournament.IPC
         {
             IPCStorage = tournamentStorage.AllTournaments;
             Logger.Log($"ipc storage path: {IPCStorage.GetFullPath(string.Empty)}");
-            string thestr = IPCStorage.Exists("ipc.txt") ? "file ipc.txt found in game storage yay" : "no ipc.txt found in game storage, uh oh";
-            Logger.Log(thestr, LoggingTarget.Runtime, LogLevel.Debug);
+            Logger.Log(IPCStorage.Exists("ipc.txt") ? "file ipc.txt found in game storage yay" : "no ipc.txt found in game storage, uh oh", LoggingTarget.Runtime, LogLevel.Debug);
 
             if (IPCStorage.Exists("ipc.txt") && ladder.UseLazerIpc.Value)
             {

--- a/osu.Game.Tournament/Models/RoundBeatmap.cs
+++ b/osu.Game.Tournament/Models/RoundBeatmap.cs
@@ -8,6 +8,7 @@ namespace osu.Game.Tournament.Models
     public class RoundBeatmap
     {
         public int ID;
+        public string MD5 = string.Empty;
         public string Mods = string.Empty;
 
         [JsonProperty("BeatmapInfo")]

--- a/osu.Game.Tournament/Models/TournamentBeatmap.cs
+++ b/osu.Game.Tournament/Models/TournamentBeatmap.cs
@@ -15,6 +15,8 @@ namespace osu.Game.Tournament.Models
 
         public string MD5Hash { get; set; } = string.Empty;
 
+        string IBeatmapInfo.MD5Hash => MD5Hash;
+
         public string DifficultyName { get; set; } = string.Empty;
 
         public double BPM { get; set; }
@@ -98,8 +100,6 @@ namespace osu.Game.Tournament.Models
         BeatmapSetNominationStatus IBeatmapSetOnlineInfo.NominationStatus => throw new NotImplementedException();
 
         string IBeatmapInfo.Hash => throw new NotImplementedException();
-
-        string IBeatmapInfo.MD5Hash => throw new NotImplementedException();
 
         IRulesetInfo IBeatmapInfo.Ruleset => throw new NotImplementedException();
 

--- a/osu.Game.Tournament/Models/TournamentBeatmap.cs
+++ b/osu.Game.Tournament/Models/TournamentBeatmap.cs
@@ -54,7 +54,7 @@ namespace osu.Game.Tournament.Models
             TotalObjectCount = beatmap.TotalObjectCount;
         }
 
-        public TournamentBeatmap(BeatmapInfo beatmap)
+        public TournamentBeatmap(BeatmapInfo beatmap, BeatmapSetOnlineCovers? covers = null)
         {
             OnlineID = beatmap.OnlineID;
             MD5Hash = beatmap.MD5Hash;
@@ -64,7 +64,8 @@ namespace osu.Game.Tournament.Models
             StarRating = beatmap.StarRating;
             Metadata = beatmap.Metadata;
             Difficulty = beatmap.Difficulty;
-            Covers = new BeatmapSetOnlineCovers();
+            // Covers = new BeatmapSetOnlineCovers { Cover = "MC_DEEZZZ.png" };
+            Covers = covers ?? new BeatmapSetOnlineCovers();
             EndTimeObjectCount = beatmap.EndTimeObjectCount;
             TotalObjectCount = beatmap.TotalObjectCount;
         }

--- a/osu.Game.Tournament/Models/TournamentBeatmap.cs
+++ b/osu.Game.Tournament/Models/TournamentBeatmap.cs
@@ -13,6 +13,8 @@ namespace osu.Game.Tournament.Models
     {
         public int OnlineID { get; set; }
 
+        public string MD5Hash { get; set; } = string.Empty;
+
         public string DifficultyName { get; set; } = string.Empty;
 
         public double BPM { get; set; }
@@ -38,6 +40,7 @@ namespace osu.Game.Tournament.Models
         public TournamentBeatmap(APIBeatmap beatmap)
         {
             OnlineID = beatmap.OnlineID;
+            MD5Hash = beatmap.MD5Hash;
             DifficultyName = beatmap.DifficultyName;
             BPM = beatmap.BPM;
             Length = beatmap.Length;
@@ -45,6 +48,21 @@ namespace osu.Game.Tournament.Models
             Metadata = beatmap.Metadata;
             Difficulty = beatmap.Difficulty;
             Covers = beatmap.BeatmapSet?.Covers ?? new BeatmapSetOnlineCovers();
+            EndTimeObjectCount = beatmap.EndTimeObjectCount;
+            TotalObjectCount = beatmap.TotalObjectCount;
+        }
+
+        public TournamentBeatmap(BeatmapInfo beatmap)
+        {
+            OnlineID = beatmap.OnlineID;
+            MD5Hash = beatmap.MD5Hash;
+            DifficultyName = beatmap.DifficultyName;
+            BPM = beatmap.BPM;
+            Length = beatmap.Length;
+            StarRating = beatmap.StarRating;
+            Metadata = beatmap.Metadata;
+            Difficulty = beatmap.Difficulty;
+            Covers = new BeatmapSetOnlineCovers();
             EndTimeObjectCount = beatmap.EndTimeObjectCount;
             TotalObjectCount = beatmap.TotalObjectCount;
         }

--- a/osu.Game.Tournament/Screens/BeatmapInfoScreen.cs
+++ b/osu.Game.Tournament/Screens/BeatmapInfoScreen.cs
@@ -48,8 +48,8 @@ namespace osu.Game.Tournament.Screens
 
         private void beatmapChanged(ValueChangedEvent<TournamentBeatmap?> beatmap)
         {
-            SongBar.FadeInFromZero(300, Easing.OutQuint);
-            SongBar.Beatmap = beatmap.NewValue;
+            SongBar.FadeOutFromOne(200, Easing.OutQuint).Then().FadeIn(300, Easing.OutQuint);
+            Scheduler.AddDelayed(() => SongBar.Beatmap = beatmap.NewValue, 200);
         }
     }
 }

--- a/osu.Game.Tournament/Screens/BeatmapInfoScreen.cs
+++ b/osu.Game.Tournament/Screens/BeatmapInfoScreen.cs
@@ -48,8 +48,7 @@ namespace osu.Game.Tournament.Screens
 
         private void beatmapChanged(ValueChangedEvent<TournamentBeatmap?> beatmap)
         {
-            // SongBar.FadeOutFromOne(200, Easing.OutQuint).Then().FadeIn(300, Easing.OutQuint);
-            Scheduler.AddDelayed(() => SongBar.Beatmap = beatmap.NewValue, 200);
+            SongBar.Beatmap = beatmap.NewValue;
         }
     }
 }

--- a/osu.Game.Tournament/Screens/BeatmapInfoScreen.cs
+++ b/osu.Game.Tournament/Screens/BeatmapInfoScreen.cs
@@ -48,7 +48,7 @@ namespace osu.Game.Tournament.Screens
 
         private void beatmapChanged(ValueChangedEvent<TournamentBeatmap?> beatmap)
         {
-            SongBar.FadeOutFromOne(200, Easing.OutQuint).Then().FadeIn(300, Easing.OutQuint);
+            // SongBar.FadeOutFromOne(200, Easing.OutQuint).Then().FadeIn(300, Easing.OutQuint);
             Scheduler.AddDelayed(() => SongBar.Beatmap = beatmap.NewValue, 200);
         }
     }

--- a/osu.Game.Tournament/Screens/Editors/RoundEditorScreen.cs
+++ b/osu.Game.Tournament/Screens/Editors/RoundEditorScreen.cs
@@ -7,13 +7,18 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Logging;
+using osu.Framework.Platform;
 using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Settings;
 using osu.Game.Tournament.Components;
+using osu.Game.Tournament.IPC;
 using osu.Game.Tournament.Models;
 using osu.Game.Tournament.Screens.Editors.Components;
 using osuTK;
@@ -23,6 +28,51 @@ namespace osu.Game.Tournament.Screens.Editors
     public partial class RoundEditorScreen : TournamentEditorScreen<RoundEditorScreen.RoundRow, TournamentRound>
     {
         protected override BindableList<TournamentRound> Storage => LadderInfo.Rounds;
+
+        [Resolved]
+        private Clipboard clipboard { get; set; } = null!;
+
+        private OsuTextBox md5TextBox = null!;
+        private readonly IBindable<TournamentBeatmap?> beatmap = new Bindable<TournamentBeatmap?>();
+
+        [BackgroundDependencyLoader]
+        private void load(LegacyMatchIPCInfo legacyIpc, MatchIPCInfo lazerIpc)
+        {
+            ControlPanel.Add(new OsuSpriteText
+            {
+                Text = "Current beatmap MD5:"
+            });
+            ControlPanel.Add(md5TextBox = new OsuTextBox
+            {
+                RelativeSizeAxes = Axes.X,
+            });
+            ControlPanel.Add(new TourneyButton
+            {
+                Text = "Copy MD5 to clipboard",
+                Action = () =>
+                {
+                    clipboard.SetText(beatmap.Value?.MD5Hash ?? string.Empty);
+                }
+            });
+
+            md5TextBox.OnCommit += (sender, newText) =>
+            {
+                Logger.Log($"sender: {sender.Text}, new text: {newText}");
+
+                if (!newText)
+                    return;
+
+                sender.Text = beatmap.Value?.MD5Hash ?? string.Empty;
+            };
+
+            LadderInfo.UseLazerIpc.BindValueChanged(vce =>
+            {
+                beatmap.UnbindAll();
+                beatmap.BindTo(vce.NewValue ? lazerIpc.Beatmap : legacyIpc.Beatmap);
+            }, true);
+
+            beatmap.BindValueChanged(vce => md5TextBox.Text = vce.NewValue?.MD5Hash ?? string.Empty, true);
+        }
 
         public partial class RoundRow : CompositeDrawable, IModelBacked<TournamentRound>
         {

--- a/osu.Game.Tournament/Screens/Editors/RoundEditorScreen.cs
+++ b/osu.Game.Tournament/Screens/Editors/RoundEditorScreen.cs
@@ -197,14 +197,21 @@ namespace osu.Game.Tournament.Screens.Editors
                                     {
                                         LabelText = "Beatmap ID",
                                         RelativeSizeAxes = Axes.None,
-                                        Width = 200,
+                                        Width = 160,
                                         Current = beatmapId,
+                                    },
+                                    new SettingsTextBox
+                                    {
+                                        LabelText = "Beatmap MD5 (fallback)",
+                                        RelativeSizeAxes = Axes.None,
+                                        Width = 320,
+                                        // Current = beatmapId,
                                     },
                                     new SettingsTextBox
                                     {
                                         LabelText = "Mods",
                                         RelativeSizeAxes = Axes.None,
-                                        Width = 200,
+                                        Width = 120,
                                         Current = mods,
                                     },
                                     drawableContainer = new Container
@@ -218,8 +225,8 @@ namespace osu.Game.Tournament.Screens.Editors
                                 Anchor = Anchor.CentreRight,
                                 Origin = Anchor.CentreRight,
                                 RelativeSizeAxes = Axes.None,
-                                Width = 150,
-                                Text = "Delete Beatmap",
+                                Width = 120,
+                                Text = "Remove",
                                 Action = () =>
                                 {
                                     Expire();

--- a/osu.Game.Tournament/Screens/Editors/RoundEditorScreen.cs
+++ b/osu.Game.Tournament/Screens/Editors/RoundEditorScreen.cs
@@ -210,6 +210,7 @@ namespace osu.Game.Tournament.Screens.Editors
                     protected IAPIProvider API { get; private set; } = null!;
 
                     private readonly Bindable<int?> beatmapId = new Bindable<int?>();
+                    private readonly Bindable<string> beatmapMd5 = new Bindable<string>(string.Empty);
 
                     private readonly Bindable<string> mods = new Bindable<string>(string.Empty);
 
@@ -255,7 +256,7 @@ namespace osu.Game.Tournament.Screens.Editors
                                         LabelText = "Beatmap MD5 (fallback)",
                                         RelativeSizeAxes = Axes.None,
                                         Width = 320,
-                                        // Current = beatmapId,
+                                        Current = beatmapMd5,
                                     },
                                     new SettingsTextBox
                                     {
@@ -319,6 +320,9 @@ namespace osu.Game.Tournament.Screens.Editors
 
                             API.Queue(req);
                         }, true);
+
+                        beatmapMd5.Value = Model.MD5;
+                        beatmapMd5.BindValueChanged(md5String => Model.MD5 = md5String.NewValue);
 
                         mods.Value = Model.Mods;
                         mods.BindValueChanged(modString => Model.Mods = modString.NewValue);

--- a/osu.Game.Tournament/Screens/Ladder/Components/LadderEditorSettings.cs
+++ b/osu.Game.Tournament/Screens/Ladder/Components/LadderEditorSettings.cs
@@ -99,7 +99,7 @@ namespace osu.Game.Tournament.Screens.Ladder.Components
         {
         }
 
-        private partial class SettingsRoundDropdown : SettingsDropdown<TournamentRound?>
+        public partial class SettingsRoundDropdown : SettingsDropdown<TournamentRound?>
         {
             public SettingsRoundDropdown(BindableList<TournamentRound> rounds)
             {

--- a/osu.Game.Tournament/Screens/Showcase/ShowcaseScreen.cs
+++ b/osu.Game.Tournament/Screens/Showcase/ShowcaseScreen.cs
@@ -1,21 +1,27 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Tournament.Components;
 using osu.Framework.Graphics.Shapes;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Overlays.Settings;
 using osu.Game.Tournament.Models;
+using osu.Game.Tournament.Screens.Ladder.Components;
 using osuTK.Graphics;
 
 namespace osu.Game.Tournament.Screens.Showcase
 {
     public partial class ShowcaseScreen : BeatmapInfoScreen
     {
+        private SettingsDropdown<TournamentRound?> roundDropdown = null!;
+
         [BackgroundDependencyLoader]
-        private void load()
+        private void load(LadderInfo ladder)
         {
             AddRangeInternal(new Drawable[]
             {
@@ -38,7 +44,19 @@ namespace osu.Game.Tournament.Screens.Showcase
                         RelativeSizeAxes = Axes.Both,
                         Colour = new Color4(0, 255, 0, 255),
                     }
+                },
+                new ControlPanel
+                {
+                    Children = new Drawable[]
+                    {
+                        roundDropdown = new LadderEditorSettings.SettingsRoundDropdown(ladder.Rounds) { LabelText = "Round" },
+                    },
                 }
+            });
+
+            roundDropdown.Current.BindValueChanged(@event =>
+            {
+                SongBar.Pool = @event.NewValue?.Beatmaps.ToList() ?? [];
             });
         }
 

--- a/osu.Game.Tournament/Screens/Showcase/ShowcaseScreen.cs
+++ b/osu.Game.Tournament/Screens/Showcase/ShowcaseScreen.cs
@@ -8,7 +8,6 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Tournament.Components;
 using osu.Framework.Graphics.Shapes;
-using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays.Settings;
 using osu.Game.Tournament.Models;
 using osu.Game.Tournament.Screens.Ladder.Components;

--- a/osu.Game.Tournament/TournamentGameBase.cs
+++ b/osu.Game.Tournament/TournamentGameBase.cs
@@ -36,6 +36,7 @@ namespace osu.Game.Tournament
 
         public const string BRACKET_FILENAME = @"bracket.json";
         private LadderInfo ladder = new LadderInfo();
+        private Storage baseStorage = null!;
         private TournamentStorage storage = null!;
         private DependencyContainer dependencies = null!;
         private LegacyFileBasedIPC ipc = null!;
@@ -81,6 +82,7 @@ namespace osu.Game.Tournament
 
             Resources.AddStore(new DllResourceStore(typeof(TournamentGameBase).Assembly));
 
+            this.baseStorage = baseStorage;
             dependencies.CacheAs<Storage>(storage = new TournamentStorage(baseStorage));
             dependencies.CacheAs(storage);
 
@@ -213,6 +215,9 @@ namespace osu.Game.Tournament
 
                 dependencies.CacheAs<MatchIPCInfo>(lazerIpc = new FileBasedIPC());
                 Add(lazerIpc);
+
+                var largeTextureStore = dependencies.Get<LargeTextureStore>();
+                largeTextureStore.AddTextureSource(Host.CreateTextureLoaderStore(new StorageBackedResourceStore(baseStorage.GetStorageForDirectory(@"tournaments"))));
 
                 bracketLoadTaskCompletionSource.SetResult(true);
 

--- a/osu.Game/Graphics/Sprites/GlowingSpriteText.cs
+++ b/osu.Game/Graphics/Sprites/GlowingSpriteText.cs
@@ -16,6 +16,11 @@ namespace osu.Game.Graphics.Sprites
 
         private OsuSpriteText text = null!;
 
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+        }
+
         public LocalisableString Text
         {
             get => text.Text;
@@ -25,7 +30,7 @@ namespace osu.Game.Graphics.Sprites
         public FontUsage Font
         {
             get => text.Font;
-            set => text.Font = value.With(fixedWidth: true);
+            set => text.Font = value;
         }
 
         public Vector2 TextSize

--- a/osu.Game/Graphics/Sprites/GlowingSpriteText.cs
+++ b/osu.Game/Graphics/Sprites/GlowingSpriteText.cs
@@ -16,11 +16,6 @@ namespace osu.Game.Graphics.Sprites
 
         private OsuSpriteText text = null!;
 
-        protected override void Dispose(bool isDisposing)
-        {
-            base.Dispose(isDisposing);
-        }
-
         public LocalisableString Text
         {
             get => text.Text;

--- a/osu.Game/Online/Leaderboards/LeaderboardScore.cs
+++ b/osu.Game/Online/Leaderboards/LeaderboardScore.cs
@@ -231,7 +231,7 @@ namespace osu.Game.Online.Leaderboards
                                             TextColour = Color4.White,
                                             GlowColour = Color4Extensions.FromHex(@"83ccfa"),
                                             Current = scoreManager.GetBindableTotalScoreString(Score),
-                                            Font = OsuFont.Numeric.With(size: 23),
+                                            Font = OsuFont.Numeric.With(size: 23, fixedWidth: true),
                                             Margin = new MarginPadding { Top = 1 },
                                         },
                                         RankContainer = new Container

--- a/osu.Game/Screens/Ranking/Expanded/Accuracy/RankText.cs
+++ b/osu.Game/Screens/Ranking/Expanded/Accuracy/RankText.cs
@@ -48,7 +48,7 @@ namespace osu.Game.Screens.Ranking.Expanded.Accuracy
                     GlowColour = OsuColour.ForRank(rank),
                     Spacing = new Vector2(-15, 0),
                     Text = DrawableRank.GetRankName(rank),
-                    Font = OsuFont.Numeric.With(size: 76),
+                    Font = OsuFont.Numeric.With(size: 76, fixedWidth: true),
                     UseFullGlyphHeight = false
                 },
                 superFlash = new BufferedContainer(cachedFrameBuffer: true)

--- a/osu.Game/TournamentIpc/TournamentFileBasedIPC.cs
+++ b/osu.Game/TournamentIpc/TournamentFileBasedIPC.cs
@@ -26,7 +26,7 @@ namespace osu.Game.TournamentIpc
         public const string SCORES = @"ipc-scores.txt";
         public const string CHAT = @"ipc-chat.txt";
         public const string BEATMAP_METADATA = @"ipc-meta.txt";
-        public const string BEATMAP_BACKGROUND = @"ipc-background.png";
+        public const string BEATMAP_BACKGROUND = @"ipc-bg.png";
     }
 
     // am I being paranoid with the locks? Not familiar with threading model in C#
@@ -176,6 +176,11 @@ namespace osu.Game.TournamentIpc
 
             // todo: serialize map background
             // var texture = workingBeatmap.Value.GetPanelBackground();
+        }
+
+        private void updateActiveBeatmapBackgroundImage()
+        {
+            // working.GetPanelBackground()
         }
 
         public void RegisterMultiplayerRoomClient(MultiplayerClient multiplayerClient)


### PR DESCRIPTION
This PR primarily adds two features to the Showcase screen in the lazer tournament client:
1. Display for the current map's slot in the upcoming mappool
2. Display non-uploaded maps

The world cups currently uses a custom overlay that mimics the looks of the lazer tournament client and uses a memory ready to fetch map information to display which slot is currently being shown, (1.) should make this unnecessary now.

Displaying non-uploaded maps is useful to avoid leaking custom maps prior to a mappool showcase (I'm guessing?)