### PR TITLE
add sliders to control chroma area in showcase screen

### DIFF
--- a/osu.Game.Tournament/Models/LadderInfo.cs
+++ b/osu.Game.Tournament/Models/LadderInfo.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using Newtonsoft.Json;
 using osu.Framework.Bindables;
 using osu.Game.Rulesets;
+using osu.Game.Tournament.Components;
 
 namespace osu.Game.Tournament.Models
 {
@@ -31,6 +32,24 @@ namespace osu.Game.Tournament.Models
         {
             MinValue = 640,
             MaxValue = 1366,
+        };
+
+        public Bindable<int> ShowcaseChromaWidth = new BindableInt(1366)
+        {
+            MinValue = 480,
+            MaxValue = 1366,
+        };
+
+        public Bindable<int> ShowcaseChromaHeight = new BindableInt(TournamentSceneManager.STREAM_AREA_HEIGHT - (int)SongBar.HEIGHT)
+        {
+            MinValue = 270,
+            MaxValue = TournamentSceneManager.STREAM_AREA_HEIGHT - (int)SongBar.HEIGHT
+        };
+
+        public Bindable<int> ShowcaseChromaVerticalOffset = new BindableInt()
+        {
+            MinValue = 0,
+            MaxValue = TournamentSceneManager.STREAM_AREA_HEIGHT - (int)SongBar.HEIGHT - 270
         };
 
         public Bindable<int> PlayersPerTeam = new BindableInt(4)

--- a/osu.Game.Tournament/Screens/Showcase/ShowcaseScreen.cs
+++ b/osu.Game.Tournament/Screens/Showcase/ShowcaseScreen.cs
@@ -18,6 +18,7 @@ namespace osu.Game.Tournament.Screens.Showcase
     public partial class ShowcaseScreen : BeatmapInfoScreen
     {
         private SettingsDropdown<TournamentRound?> roundDropdown = null!;
+        private Drawable chroma = null!;
 
         [BackgroundDependencyLoader]
         private void load(LadderInfo ladder)
@@ -34,13 +35,14 @@ namespace osu.Game.Tournament.Screens.Showcase
                 {
                     Padding = new MarginPadding { Bottom = SongBar.HEIGHT },
                     RelativeSizeAxes = Axes.Both,
-                    Child = new Box
+                    Child = chroma = new Box
                     {
                         // chroma key area for stable gameplay
                         Name = "chroma",
-                        Anchor = Anchor.TopCentre,
-                        Origin = Anchor.TopCentre,
-                        RelativeSizeAxes = Axes.Both,
+                        Anchor = Anchor.BottomCentre,
+                        Origin = Anchor.BottomCentre,
+                        Height = 512,
+                        Y = 0,
                         Colour = new Color4(0, 255, 0, 255),
                     }
                 },
@@ -49,6 +51,34 @@ namespace osu.Game.Tournament.Screens.Showcase
                     Children = new Drawable[]
                     {
                         roundDropdown = new LadderEditorSettings.SettingsRoundDropdown(ladder.Rounds) { LabelText = "Round" },
+                        new SettingsSlider<int>
+                        {
+                            LabelText = "Chroma width",
+                            Current = LadderInfo.ShowcaseChromaWidth,
+                            KeyboardStep = 1,
+                        },
+                        new SettingsSlider<int>
+                        {
+                            LabelText = "Chroma height",
+                            Current = LadderInfo.ShowcaseChromaHeight,
+                            KeyboardStep = 1,
+                        },
+                        new SettingsSlider<int>
+                        {
+                            LabelText = "Chroma offset",
+                            Current = LadderInfo.ShowcaseChromaVerticalOffset,
+                            KeyboardStep = 1,
+                        },
+                        new TourneyButton
+                        {
+                            Text = "Set 16:9 ratio from width",
+                            Action = () => LadderInfo.ShowcaseChromaHeight.Value = LadderInfo.ShowcaseChromaWidth.Value / 16 * 9
+                        },
+                        new TourneyButton
+                        {
+                            Text = "Set 16:9 ratio from height",
+                            Action = () => LadderInfo.ShowcaseChromaWidth.Value = LadderInfo.ShowcaseChromaHeight.Value * 16 / 9
+                        }
                     },
                 }
             });
@@ -57,6 +87,10 @@ namespace osu.Game.Tournament.Screens.Showcase
             {
                 SongBar.Pool = @event.NewValue?.Beatmaps.ToList() ?? [];
             });
+
+            LadderInfo.ShowcaseChromaWidth.BindValueChanged(width => chroma.Width = width.NewValue, true);
+            LadderInfo.ShowcaseChromaHeight.BindValueChanged(height => chroma.Height = height.NewValue, true);
+            LadderInfo.ShowcaseChromaVerticalOffset.BindValueChanged(offset => chroma.Y = -offset.NewValue, true);
         }
 
         protected override void CurrentMatchChanged(ValueChangedEvent<TournamentMatch?> match)


### PR DESCRIPTION
Slider values are persisted into the `bracket.json` file

https://github.com/user-attachments/assets/1d7316f5-e071-426d-83e6-64364ae75478

