### PR TITLE
add option to toggle auto-expand of PlayerSettingsOverlay on hover

### DIFF
--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -222,6 +222,8 @@ namespace osu.Game.Configuration
 
             SetDefault(OsuSetting.EditorSubmissionNotifyOnDiscussionReplies, true);
             SetDefault(OsuSetting.EditorSubmissionLoadInBrowserAfterSubmission, true);
+
+            SetDefault(OsuSetting.ExpandPlayerSettingsOverlayOnHover, true);
         }
 
         protected override bool CheckLookupContainsPrivateInformation(OsuSetting lookup)
@@ -463,5 +465,7 @@ namespace osu.Game.Configuration
         EditorShowStoryboard,
         EditorSubmissionNotifyOnDiscussionReplies,
         EditorSubmissionLoadInBrowserAfterSubmission,
+
+        ExpandPlayerSettingsOverlayOnHover,
     }
 }

--- a/osu.Game/Overlays/Settings/Sections/Gameplay/HUDSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Gameplay/HUDSettings.cs
@@ -29,6 +29,13 @@ namespace osu.Game.Overlays.Settings.Sections.Gameplay
                     Current = config.GetBindable<bool>(OsuSetting.ReplaySettingsOverlay),
                     Keywords = new[] { "hide" },
                 },
+
+                new SettingsCheckbox
+                {
+                    LabelText = @"Automatically expand replay settings overlay on hover",
+                    Current = config.GetBindable<bool>(OsuSetting.ExpandPlayerSettingsOverlayOnHover),
+                    Keywords = new[] { "overlay" },
+                },
                 new SettingsCheckbox
                 {
                     LabelText = GameplaySettingsStrings.AlwaysShowKeyOverlay,

--- a/osu.Game/Screens/Play/HUD/PlayerSettingsOverlay.cs
+++ b/osu.Game/Screens/Play/HUD/PlayerSettingsOverlay.cs
@@ -8,7 +8,6 @@ using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
-using osu.Framework.Input;
 using osu.Framework.Input.Events;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
@@ -41,8 +40,6 @@ namespace osu.Game.Screens.Play.HUD
         private readonly FillFlowContainer content;
 
         private readonly IconButton button;
-
-        private InputManager inputManager = null!;
 
         [Resolved]
         private HUDOverlay? hudOverlay { get; set; }
@@ -88,21 +85,7 @@ namespace osu.Game.Screens.Play.HUD
             });
         }
 
-        protected override void LoadComplete()
-        {
-            base.LoadComplete();
-
-            inputManager = GetContainingInputManager()!;
-        }
-
-        public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) =>
-            screenSpacePos.X > button.ScreenSpaceDrawQuad.TopLeft.X;
-
-        protected override bool OnMouseMove(MouseMoveEvent e)
-        {
-            checkExpanded();
-            return base.OnMouseMove(e);
-        }
+        public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => false;
 
         protected override void Update()
         {
@@ -110,22 +93,6 @@ namespace osu.Game.Screens.Play.HUD
 
             if (hudOverlay != null)
                 button.Y = ToLocalSpace(hudOverlay.TopRightElements.ScreenSpaceDrawQuad.BottomRight).Y;
-
-            // Only check expanded if already expanded.
-            // This is because if we are always checking, it would bypass blocking overlays.
-            // Case in point: the skin editor overlay blocks input from reaching the player, but checking raw coordinates would make settings pop out.
-            if (Expanded.Value)
-                checkExpanded();
-        }
-
-        private void checkExpanded()
-        {
-            float screenMouseX = inputManager.CurrentState.Mouse.Position.X;
-
-            Expanded.Value =
-                (screenMouseX >= button.ScreenSpaceDrawQuad.TopLeft.X && screenMouseX <= ToScreenSpace(new Vector2(DrawWidth + EXPANDED_WIDTH, 0)).X)
-                // Stay expanded if the user is dragging a slider.
-                || inputManager.DraggedDrawable != null;
         }
 
         protected override void OnHoverLost(HoverLostEvent e)


### PR DESCRIPTION
cog button is still usable to show settings overlay

closes #51 