### PR TITLE
add 1v1 mode and QoL teams navigation to tourney seed screen

### DIFF
--- a/osu.Game.Tournament.Tests/Screens/TestSceneSeedingScreen.cs
+++ b/osu.Game.Tournament.Tests/Screens/TestSceneSeedingScreen.cs
@@ -49,7 +49,7 @@ namespace osu.Game.Tournament.Tests.Screens
                 FillAspectRatio = 16 / 9f
             }));
 
-            AddStep("set team to Japan", () => this.ChildrenOfType<SettingsTeamDropdown>().Single().Current.Value = ladder.Teams.Single());
+            AddStep("set team to Japan", () => this.ChildrenOfType<SettingsTeamDropdown>().Single().Current.Value = ladder.Teams.First());
         }
     }
 }

--- a/osu.Game.Tournament.Tests/Screens/TestSceneSeedingScreen.cs
+++ b/osu.Game.Tournament.Tests/Screens/TestSceneSeedingScreen.cs
@@ -23,17 +23,56 @@ namespace osu.Game.Tournament.Tests.Screens
                 {
                     FullName = { Value = @"Japan" },
                     Acronym = { Value = "JPN" },
+                    Seed = { Value = @"1" },
                     SeedingResults =
                     {
                         new SeedingResult
                         {
                             // Mod intentionally left blank.
-                            Seed = { Value = 4 }
+                            Seed = { Value = 1 }
                         },
                         new SeedingResult
                         {
                             Mod = { Value = "DT" },
-                            Seed = { Value = 8 }
+                            Seed = { Value = 2 }
+                        }
+                    }
+                },
+                new TournamentTeam
+                {
+                    FullName = { Value = @"bbbbb" },
+                    Acronym = { Value = "BBB" },
+                    Seed = { Value = @"2" },
+                    SeedingResults =
+                    {
+                        new SeedingResult
+                        {
+                            // Mod intentionally left blank.
+                            Seed = { Value = 2 }
+                        },
+                        new SeedingResult
+                        {
+                            Mod = { Value = "DT" },
+                            Seed = { Value = 3 }
+                        }
+                    }
+                },
+                new TournamentTeam
+                {
+                    FullName = { Value = @"CCC" },
+                    Acronym = { Value = "C" },
+                    Seed = { Value = @"3" },
+                    SeedingResults =
+                    {
+                        new SeedingResult
+                        {
+                            // Mod intentionally left blank.
+                            Seed = { Value = 3 }
+                        },
+                        new SeedingResult
+                        {
+                            Mod = { Value = "DT" },
+                            Seed = { Value = 4 }
                         }
                     }
                 }

--- a/osu.Game.Tournament/Models/LadderInfo.cs
+++ b/osu.Game.Tournament/Models/LadderInfo.cs
@@ -62,6 +62,8 @@ namespace osu.Game.Tournament.Models
 
         public Bindable<bool> UseLazerIpc = new Bindable<bool>(true);
 
+        public Bindable<bool> Use1V1Mode = new Bindable<bool>(false);
+
         public Bindable<bool> SplitMapPoolByMods = new BindableBool(true);
 
         public Bindable<bool> DisplayTeamSeeds = new BindableBool();

--- a/osu.Game.Tournament/Screens/TeamIntro/SeedingScreen.cs
+++ b/osu.Game.Tournament/Screens/TeamIntro/SeedingScreen.cs
@@ -11,6 +11,7 @@ using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Overlays.Settings;
 using osu.Game.Tournament.Components;
 using osu.Game.Tournament.Models;
 using osu.Game.Tournament.Screens.Ladder.Components;
@@ -63,12 +64,18 @@ namespace osu.Game.Tournament.Screens.TeamIntro
                         {
                             LabelText = "Show specific team",
                             Current = currentTeam,
+                        },
+                        new SettingsCheckbox
+                        {
+                            LabelText = "1v1 mode",
+                            Current = LadderInfo.Use1V1Mode
                         }
                     }
                 }
             };
 
             currentTeam.BindValueChanged(teamChanged, true);
+            LadderInfo.Use1V1Mode.BindValueChanged(_ => updateTeamDisplay());
         }
 
         private void teamChanged(ValueChangedEvent<TournamentTeam?> team) => updateTeamDisplay();
@@ -109,7 +116,7 @@ namespace osu.Game.Tournament.Screens.TeamIntro
 
             mainContainer.Children = new Drawable[]
             {
-                new LeftInfo(currentTeam.Value) { Position = new Vector2(55, 150), },
+                new LeftInfo(currentTeam.Value, LadderInfo.Use1V1Mode.Value) { Position = new Vector2(55, 150), },
                 new RightInfo(currentTeam.Value) { Position = new Vector2(500, 150), },
             };
         });
@@ -254,7 +261,7 @@ namespace osu.Game.Tournament.Screens.TeamIntro
 
         private partial class LeftInfo : CompositeDrawable
         {
-            public LeftInfo(TournamentTeam? team)
+            public LeftInfo(TournamentTeam? team, bool use1V1Mode)
             {
                 FillFlowContainer fill;
 
@@ -272,13 +279,16 @@ namespace osu.Game.Tournament.Screens.TeamIntro
                         Children = new Drawable[]
                         {
                             new TeamDisplay(team) { Margin = new MarginPadding { Bottom = 30 } },
-                            new RowDisplay("Average Rank:", $"#{team.AverageRank:#,0}"),
+                            new RowDisplay(use1V1Mode ? "Rank:" : "Average Rank:", $"#{team.AverageRank:#,0}"),
                             new RowDisplay("Seed:", team.Seed.Value),
                             new RowDisplay("Last year's placing:", team.LastYearPlacing.Value > 0 ? $"#{team.LastYearPlacing:#,0}" : "N/A"),
                             new Container { Margin = new MarginPadding { Bottom = 30 } },
                         }
                     },
                 };
+
+                if (use1V1Mode)
+                    return;
 
                 foreach (var p in team.Players)
                     fill.Add(new RowDisplay(p.Username, p.Rank?.ToString("\\##,0") ?? "-"));

--- a/osu.Game.Tournament/Screens/TeamIntro/SeedingScreen.cs
+++ b/osu.Game.Tournament/Screens/TeamIntro/SeedingScreen.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Diagnostics;
+using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -16,6 +17,19 @@ using osu.Game.Tournament.Components;
 using osu.Game.Tournament.Models;
 using osu.Game.Tournament.Screens.Ladder.Components;
 using osuTK;
+
+internal static class BindableListExtensions
+{
+    public static (T? previous, T? next) GetPreviousAndNext<T>(this BindableList<T> list, T currentElement)
+    {
+        int currentIndex = list.IndexOf(currentElement);
+
+        T? previousElement = currentIndex != -1 && currentIndex > 0 ? list[currentIndex - 1] : list.FirstOrDefault();
+        T? nextElement = currentIndex != -1 && currentIndex < list.Count - 1 ? list[currentIndex + 1] : list.LastOrDefault();
+
+        return (previousElement, nextElement);
+    }
+}
 
 namespace osu.Game.Tournament.Screens.TeamIntro
 {
@@ -64,6 +78,18 @@ namespace osu.Game.Tournament.Screens.TeamIntro
                         {
                             LabelText = "Show specific team",
                             Current = currentTeam,
+                        },
+                        new TourneyButton
+                        {
+                            RelativeSizeAxes = Axes.X,
+                            Text = "Move to team above",
+                            Action = () => currentTeam.Value = LadderInfo.Teams!.GetPreviousAndNext(currentTeam.Value).previous,
+                        },
+                        new TourneyButton
+                        {
+                            RelativeSizeAxes = Axes.X,
+                            Text = "Move to team below",
+                            Action = () => currentTeam.Value = LadderInfo.Teams!.GetPreviousAndNext(currentTeam.Value).next,
                         },
                         new SettingsCheckbox
                         {


### PR DESCRIPTION
Buttons in seeding screen:
- if no match selected, 
  - "move to team above" will show top team
  - "move to team below" will show bottom team
- if a team is selected, buttons moves up and down the list

- 1v1 toggles "Average rank" vs "Rank" and toggles the display of team members (1v1 means team name is the user's name).