### PR TITLE
add text colour picker to tourney overlay

### DIFF
--- a/osu.Game.Tournament/Models/LadderInfo.cs
+++ b/osu.Game.Tournament/Models/LadderInfo.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 using osu.Framework.Bindables;
+using osu.Framework.Graphics;
 using osu.Game.Rulesets;
 using osu.Game.Tournament.Components;
 
@@ -69,5 +70,7 @@ namespace osu.Game.Tournament.Models
         public Bindable<bool> DisplayTeamSeeds = new BindableBool();
 
         public Bindable<bool> CumulativeScore = new BindableBool();
+
+        public Bindable<Colour4> TextForegroundColour = new Bindable<Colour4>(Colour4.White);
     }
 }

--- a/osu.Game.Tournament/Screens/Setup/SetupScreen.cs
+++ b/osu.Game.Tournament/Screens/Setup/SetupScreen.cs
@@ -170,6 +170,14 @@ namespace osu.Game.Tournament.Screens.Setup
                     Label = "Use cumulative score",
                     Description = "Instead of a single point per map won, a team's points value tracks the total score achieved on each map.",
                     Current = LadderInfo.CumulativeScore
+                },
+                new LabelledColourPicker
+                {
+                    Label = "Default text colour",
+                    LabelAnchor = Anchor.TopLeft,
+                    LabelOrigin = Anchor.TopLeft,
+                    Description = "The colour text elements will have if they use the default white colour. Will not affect elements which use a different colour.",
+                    Current = { BindTarget = LadderInfo.TextForegroundColour }
                 }
             };
         }

--- a/osu.Game.Tournament/Screens/TeamIntro/SeedingScreen.cs
+++ b/osu.Game.Tournament/Screens/TeamIntro/SeedingScreen.cs
@@ -11,7 +11,7 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
 using osu.Game.Graphics;
-using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Overlays.Settings;
 using osu.Game.Tournament.Components;
 using osu.Game.Tournament.Models;
@@ -95,6 +95,20 @@ namespace osu.Game.Tournament.Screens.TeamIntro
                         {
                             LabelText = "1v1 mode",
                             Current = LadderInfo.Use1V1Mode
+                        },
+                        new TournamentSpriteText
+                        {
+                            Margin = new MarginPadding { Top = 12 },
+                            Anchor = Anchor.TopCentre,
+                            Origin = Anchor.TopCentre,
+                            Text = "Text foreground colour",
+                            Font = OsuFont.GetFont(weight: FontWeight.Bold, size: 14)
+                        },
+                        new OsuColourPicker
+                        {
+                            RelativeSizeAxes = Axes.X,
+                            Width = 1.0f,
+                            Current = { BindTarget = LadderInfo.TextForegroundColour }
                         }
                     }
                 }
@@ -365,7 +379,7 @@ namespace osu.Game.Tournament.Screens.TeamIntro
                         Children = new Drawable[]
                         {
                             Flag,
-                            new OsuSpriteText
+                            new TournamentSpriteText
                             {
                                 Text = team?.FullName.Value ?? "???",
                                 Font = OsuFont.Torus.With(size: 32, weight: FontWeight.SemiBold),

--- a/osu.Game.Tournament/TournamentSpriteText.cs
+++ b/osu.Game.Tournament/TournamentSpriteText.cs
@@ -1,16 +1,31 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Allocation;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Tournament.Models;
+using osuTK.Graphics;
 
 namespace osu.Game.Tournament
 {
     public partial class TournamentSpriteText : OsuSpriteText
     {
+        [Resolved(CanBeNull = true)]
+        private LadderInfo? ladderInfo { get; set; }
+
         public TournamentSpriteText()
         {
             Font = OsuFont.Torus;
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            // only apply override if not default colour
+            if (Colour == Color4.White)
+                ladderInfo?.TextForegroundColour.BindValueChanged(vce => Colour = vce.NewValue);
         }
     }
 }

--- a/osu.Game/Graphics/UserInterfaceV2/LabelledColourPicker.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/LabelledColourPicker.cs
@@ -1,0 +1,17 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+
+namespace osu.Game.Graphics.UserInterfaceV2
+{
+    public partial class LabelledColourPicker : LabelledComponent<OsuColourPicker, Colour4>
+    {
+        public LabelledColourPicker()
+            : base(true)
+        {
+        }
+
+        protected override OsuColourPicker CreateComponent() => new OsuColourPicker();
+    }
+}

--- a/osu.Game/Graphics/UserInterfaceV2/LabelledDrawable.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/LabelledDrawable.cs
@@ -161,6 +161,16 @@ namespace osu.Game.Graphics.UserInterfaceV2
             set => labelText.Text = value;
         }
 
+        public Anchor LabelAnchor
+        {
+            set => labelText.Anchor = value;
+        }
+
+        public Anchor LabelOrigin
+        {
+            set => labelText.Origin = value;
+        }
+
         public LocalisableString Description
         {
             set


### PR DESCRIPTION
only overrides text colour of `TournamentSpriteText` which doesn't have a custom `Colour` set (e.g. will only affect text that was originally white)