### PR TITLE
prep LGA client for first week of streams

### DIFF
--- a/osu.Game.Tournament.Tests/Screens/TestSceneGameplayScreen.cs
+++ b/osu.Game.Tournament.Tests/Screens/TestSceneGameplayScreen.cs
@@ -10,6 +10,7 @@ using osu.Framework.Testing;
 using osu.Framework.Utils;
 using osu.Game.Tournament.Components;
 using osu.Game.Tournament.IPC;
+using osu.Game.Tournament.Models;
 using osu.Game.Tournament.Screens.Gameplay;
 using osu.Game.Tournament.Screens.Gameplay.Components;
 using osu.Game.TournamentIpc;
@@ -63,15 +64,37 @@ namespace osu.Game.Tournament.Tests.Screens
             createScreen();
             toggleWarmup();
 
-            AddStep("set state: lobby", () => LazerIPCInfo.State.Value = TourneyState.Lobby);
+            AddStep("add set with maps 1 & 2", () => Ladder.CurrentMatch.Value!.Sets.Add(new MatchSet { Map1Id = { Value = 1 }, Map2Id = { Value = 2 } }));
+            AddStep("add set with maps 3 & 4", () => Ladder.CurrentMatch.Value!.Sets.Add(new MatchSet { Map1Id = { Value = 3 }, Map2Id = { Value = 4 } }));
 
-            AddStep("set state: playing", () => LazerIPCInfo.State.Value = TourneyState.Playing);
-            AddStep("add score", () =>
+            for (int i = 0; i < 2; i++)
             {
-                LazerIPCInfo.Score1.Value = 127_727;
-                LazerIPCInfo.Score2.Value = 63_727;
-            });
-            AddStep("set state: ranking", () => LazerIPCInfo.State.Value = TourneyState.Ranking);
+                int i1 = i;
+                AddStep($"switch to map {i + 1}", () => LazerIPCInfo.Beatmap.Value = new TournamentBeatmap { OnlineID = i1 + 1 });
+
+                AddStep("set state: lobby", () => LazerIPCInfo.State.Value = TourneyState.Lobby);
+
+                AddStep("set state: playing", () => LazerIPCInfo.State.Value = TourneyState.Playing);
+
+                int iteration = i;
+                AddStep("add score", () =>
+                {
+                    LazerIPCInfo.Score1.Value = iteration == 0 ? 127_727 : 492_000;
+                    LazerIPCInfo.Score2.Value = iteration == 0 ? 63_000 : 613_727;
+                });
+                AddStep("set state: ranking", () => LazerIPCInfo.State.Value = TourneyState.Ranking);
+
+                AddWaitStep("wait a bit", 8);
+
+                AddStep("clear scores", () =>
+                {
+                    LazerIPCInfo.Score1.Value = 0;
+                    LazerIPCInfo.Score2.Value = 0;
+                });
+            }
+
+            AddStep("set state: lobby", () => LazerIPCInfo.State.Value = TourneyState.Lobby);
+            AddStep("switch to map 3", () => LazerIPCInfo.Beatmap.Value = new TournamentBeatmap { OnlineID = 3 });
         }
 
         [Test]

--- a/osu.Game.Tournament.Tests/Screens/TestSceneGameplayScreen.cs
+++ b/osu.Game.Tournament.Tests/Screens/TestSceneGameplayScreen.cs
@@ -64,8 +64,8 @@ namespace osu.Game.Tournament.Tests.Screens
             createScreen();
             toggleWarmup();
 
-            AddStep("add set with maps 1 & 2", () => Ladder.CurrentMatch.Value!.Sets.Add(new MatchSet { Map1Id = { Value = 1 }, Map2Id = { Value = 2 } }));
-            AddStep("add set with maps 3 & 4", () => Ladder.CurrentMatch.Value!.Sets.Add(new MatchSet { Map1Id = { Value = 3 }, Map2Id = { Value = 4 } }));
+            AddStep("add set with maps 1 & 2", () => Ladder.CurrentMatch.Value!.Sets.Add(new MatchSet(false) { Map1Id = { Value = 1 }, Map2Id = { Value = 2 } }));
+            AddStep("add set with maps 3 & 4", () => Ladder.CurrentMatch.Value!.Sets.Add(new MatchSet(false) { Map1Id = { Value = 3 }, Map2Id = { Value = 4 } }));
 
             for (int i = 0; i < 2; i++)
             {
@@ -95,6 +95,44 @@ namespace osu.Game.Tournament.Tests.Screens
 
             AddStep("set state: lobby", () => LazerIPCInfo.State.Value = TourneyState.Lobby);
             AddStep("switch to map 3", () => LazerIPCInfo.Beatmap.Value = new TournamentBeatmap { OnlineID = 3 });
+        }
+
+        [Test]
+        public void TestScoreAddCumulativeTiebreaker()
+        {
+            AddStep("disable cumulative score", () => Ladder.CumulativeScore.Value = false);
+            AddStep("enable cumulative score", () => Ladder.CumulativeScore.Value = true);
+
+            createScreen();
+            toggleWarmup();
+
+            AddStep("add tiebreaker set with maps 3, 4, 5", () => Ladder.CurrentMatch.Value!.Sets.Add(new MatchSet(true) { Map1Id = { Value = 1 }, Map2Id = { Value = 2 }, Map3Id = { Value = 3 } }));
+
+            for (int i = 0; i < 3; i++)
+            {
+                int i1 = i;
+                AddStep($"switch to map {i + 1}", () => LazerIPCInfo.Beatmap.Value = new TournamentBeatmap { OnlineID = i1 + 1 });
+
+                AddStep("set state: lobby", () => LazerIPCInfo.State.Value = TourneyState.Lobby);
+
+                AddStep("set state: playing", () => LazerIPCInfo.State.Value = TourneyState.Playing);
+
+                int iteration = i + 1;
+                AddStep("add score", () =>
+                {
+                    LazerIPCInfo.Score1.Value = iteration * 1_000;
+                    LazerIPCInfo.Score2.Value = iteration;
+                });
+                AddStep("set state: ranking", () => LazerIPCInfo.State.Value = TourneyState.Ranking);
+
+                AddWaitStep("wait a bit", 8);
+
+                AddStep("clear scores", () =>
+                {
+                    LazerIPCInfo.Score1.Value = 0;
+                    LazerIPCInfo.Score2.Value = 0;
+                });
+            }
         }
 
         [Test]

--- a/osu.Game.Tournament.Tests/Screens/TestSceneGameplayScreen.cs
+++ b/osu.Game.Tournament.Tests/Screens/TestSceneGameplayScreen.cs
@@ -57,6 +57,7 @@ namespace osu.Game.Tournament.Tests.Screens
         [Test]
         public void TestScoreAddCumulative()
         {
+            AddStep("disable cumulative score", () => Ladder.CumulativeScore.Value = false);
             AddStep("enable cumulative score", () => Ladder.CumulativeScore.Value = true);
 
             createScreen();

--- a/osu.Game.Tournament.Tests/Screens/TestSceneMapPoolScreen.cs
+++ b/osu.Game.Tournament.Tests/Screens/TestSceneMapPoolScreen.cs
@@ -55,12 +55,15 @@ namespace osu.Game.Tournament.Tests.Screens
 
                 for (int i = 0; i < 4; i++)
                     addBeatmap("NM", $"NM map #{i}");
-                for (int i = 0; i < 2; i++)
+                for (int i = 0; i < 3; i++)
                     addBeatmap("HD", $"HD map #{i}");
-                for (int i = 0; i < 2; i++)
+                for (int i = 0; i < 3; i++)
                     addBeatmap("HR", $"HR map #{i}");
                 for (int i = 0; i < 3; i++)
                     addBeatmap("DT", $"DT map #{i}");
+
+                addBeatmap("LM", "LM1");
+                addBeatmap("OG", "OG1");
 
                 resetState();
             });

--- a/osu.Game.Tournament.Tests/Screens/TestSceneMapPoolScreen.cs
+++ b/osu.Game.Tournament.Tests/Screens/TestSceneMapPoolScreen.cs
@@ -488,11 +488,15 @@ namespace osu.Game.Tournament.Tests.Screens
         private void addBeatmap(string mods = "NM", string? titleOverride = null)
         {
             var newBeatmap = CreateSampleBeatmap(titleOverride);
+
+            int modSlotIndex = Ladder.CurrentMatch.Value!.Round.Value!.Beatmaps.Count(bm => bm.Mods == mods) + 1;
+
             Ladder.CurrentMatch.Value!.Round.Value!.Beatmaps.Add(new RoundBeatmap
             {
                 Beatmap = newBeatmap,
                 ID = newBeatmap.OnlineID,
-                Mods = mods
+                Mods = mods,
+                SlotName = $"{mods}{modSlotIndex}"
             });
         }
 

--- a/osu.Game.Tournament.Tests/Screens/TestSceneMapPoolScreen.cs
+++ b/osu.Game.Tournament.Tests/Screens/TestSceneMapPoolScreen.cs
@@ -6,10 +6,12 @@ using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
+using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Testing;
 using osu.Game.Tournament.Components;
 using osu.Game.Tournament.Models;
+using osu.Game.Tournament.Screens.Gameplay;
 using osu.Game.Tournament.Screens.MapPool;
 using osuTK;
 using osuTK.Input;
@@ -18,12 +20,16 @@ namespace osu.Game.Tournament.Tests.Screens
 {
     public partial class TestSceneMapPoolScreen : TournamentScreenTestScene
     {
+        [Cached]
+        private TournamentMatchChatDisplay chat = new TournamentMatchChatDisplay { Width = 0.5f };
+
         private MapPoolScreen screen = null!;
 
         [BackgroundDependencyLoader]
         private void load()
         {
             Add(screen = new TestMapPoolScreen { Width = 0.7f });
+            Add(chat);
         }
 
         [SetUpSteps]
@@ -38,6 +44,7 @@ namespace osu.Game.Tournament.Tests.Screens
 
             Ladder.CurrentMatch.Value = new TournamentMatch();
             Ladder.Matches.First().PicksBans.Clear();
+            Ladder.Matches.First().Sets.Clear();
             Ladder.CurrentMatch.Value = Ladder.Matches.First();
         }
 
@@ -49,6 +56,8 @@ namespace osu.Game.Tournament.Tests.Screens
         [Test]
         public void TestLazerGrandArena()
         {
+            int pickIndex = 0;
+
             AddStep("load first weekend maps", () =>
             {
                 Ladder.CurrentMatch.Value!.Round.Value!.Beatmaps.Clear();
@@ -66,7 +75,15 @@ namespace osu.Game.Tournament.Tests.Screens
                 addBeatmap("OG", "OG1");
 
                 resetState();
+                pickIndex = 0;
             });
+
+            AddRepeatStep("Pick maps", () =>
+            {
+
+                screen.ChildrenOfType<TourneyButton>().First(btn => btn.Text == $"{(pickIndex % 2 == 0 ? "Red" : "Blue")} Pick").TriggerClick();
+                clickBeatmapPanel(pickIndex++);
+            }, 10);
         }
 
         [Test]

--- a/osu.Game.Tournament.Tests/Screens/TestSceneMapPoolScreen.cs
+++ b/osu.Game.Tournament.Tests/Screens/TestSceneMapPoolScreen.cs
@@ -6,12 +6,10 @@ using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
-using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Testing;
 using osu.Game.Tournament.Components;
 using osu.Game.Tournament.Models;
-using osu.Game.Tournament.Screens.Gameplay;
 using osu.Game.Tournament.Screens.MapPool;
 using osuTK;
 using osuTK.Input;
@@ -78,12 +76,7 @@ namespace osu.Game.Tournament.Tests.Screens
                 pickIndex = 0;
             });
 
-            AddRepeatStep("Pick maps", () =>
-            {
-
-                screen.ChildrenOfType<TourneyButton>().First(btn => btn.Text == $"{(pickIndex % 2 == 0 ? "Red" : "Blue")} Pick").TriggerClick();
-                clickBeatmapPanel(pickIndex++);
-            }, 10);
+            AddRepeatStep("perform picks/bans", () => clickBeatmapPanel(pickIndex++), 4 + 5 * 2); // 4 bans, up to 5 sets of 2 picks
         }
 
         [Test]

--- a/osu.Game.Tournament.Tests/Screens/TestSceneMapPoolScreen.cs
+++ b/osu.Game.Tournament.Tests/Screens/TestSceneMapPoolScreen.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
@@ -60,9 +61,37 @@ namespace osu.Game.Tournament.Tests.Screens
                     addBeatmap("HR", $"HR map #{i}");
                 for (int i = 0; i < 3; i++)
                     addBeatmap("DT", $"DT map #{i}");
+
+                resetState();
+            });
+        }
+
+        [Test]
+        public void TestLgaSetScoring()
+        {
+            AddStep("load first weekend maps", () =>
+            {
+                Ladder.CurrentMatch.Value!.Round.Value!.Beatmaps.Clear();
+
+                for (int i = 0; i < 4; i++)
+                    addBeatmap("NM", $"NM map #{i}");
+                for (int i = 0; i < 2; i++)
+                    addBeatmap("HD", $"HD map #{i}");
+                for (int i = 0; i < 2; i++)
+                    addBeatmap("HR", $"HR map #{i}");
+                for (int i = 0; i < 3; i++)
+                    addBeatmap("DT", $"DT map #{i}");
+
+                resetState();
             });
 
-            AddStep("reset state", resetState);
+            AddStep("set red pick", () => screen.ChildrenOfType<TourneyButton>().First(btn => btn.Text == "Red Pick").TriggerClick());
+            AddStep("pick nm1", () => clickBeatmapPanel(0));
+            AddStep("set scores on nm1", () => Ladder.CurrentMatch.Value!.MapScores["NM1"] = new Tuple<long, long>(Random.Shared.Next() % 1_000_000, Random.Shared.Next() % 1_000_000));
+
+            AddStep("set blue pick", () => screen.ChildrenOfType<TourneyButton>().First(btn => btn.Text == "Blue Pick").TriggerClick());
+            AddStep("pick nm2", () => clickBeatmapPanel(1));
+            AddStep("set scores on nm2", () => Ladder.CurrentMatch.Value!.MapScores["NM2"] = new Tuple<long, long>(Random.Shared.Next() % 1_000_000, Random.Shared.Next() % 1_000_000));
         }
 
         [Test]

--- a/osu.Game.Tournament.Tests/TournamentScreenTestScene.cs
+++ b/osu.Game.Tournament.Tests/TournamentScreenTestScene.cs
@@ -26,13 +26,6 @@ namespace osu.Game.Tournament.Tests
                 TargetDrawSize = new Vector2(1024, 768);
                 RelativeSizeAxes = Axes.Both;
             }
-
-            protected override void Update()
-            {
-                base.Update();
-
-                Scale = new Vector2(Math.Min(1, Content.DrawWidth / (1920 + TournamentSceneManager.CONTROL_AREA_WIDTH)));
-            }
         }
     }
 }

--- a/osu.Game.Tournament.Tests/TournamentTestScene.cs
+++ b/osu.Game.Tournament.Tests/TournamentTestScene.cs
@@ -171,6 +171,7 @@ namespace osu.Game.Tournament.Tests
                         new RoundBeatmap { ID = 2, SlotName = "NM2" },
                         new RoundBeatmap { ID = 3, SlotName = "HD1" },
                         new RoundBeatmap { ID = 4, SlotName = "HD2" },
+                        new RoundBeatmap { ID = 5, SlotName = "TB1" },
                     }
                 },
             }

--- a/osu.Game.Tournament.Tests/TournamentTestScene.cs
+++ b/osu.Game.Tournament.Tests/TournamentTestScene.cs
@@ -61,6 +61,7 @@ namespace osu.Game.Tournament.Tests
             {
                 match.Team1Score.Value = 0;
                 match.Team2Score.Value = 0;
+                match.MapScores.Clear();
                 Ladder.CurrentMatch.Value = match;
             });
         }
@@ -161,7 +162,17 @@ namespace osu.Game.Tournament.Tests
             },
             Round =
             {
-                Value = new TournamentRound { Name = { Value = "Quarterfinals" } },
+                Value = new TournamentRound
+                {
+                    Name = { Value = "Quarterfinals" },
+                    Beatmaps =
+                    {
+                        new RoundBeatmap { ID = 1, SlotName = "NM1" },
+                        new RoundBeatmap { ID = 2, SlotName = "NM2" },
+                        new RoundBeatmap { ID = 3, SlotName = "HD1" },
+                        new RoundBeatmap { ID = 4, SlotName = "HD2" },
+                    }
+                },
             }
         };
 

--- a/osu.Game.Tournament/Components/SongBar.cs
+++ b/osu.Game.Tournament/Components/SongBar.cs
@@ -75,8 +75,14 @@ namespace osu.Game.Tournament.Components
         }
 
         // private readonly Dictionary<int, string> poolSlotsText = new Dictionary<int, string>();
+        /// <summary>
+        /// Dict:
+        /// - key: tuple(onlineId, Md5)
+        /// - value: slot name
+        /// </summary>
         private readonly Dictionary<(int, string), string> poolSlotsText = new Dictionary<(int, string), string>();
 
+        // TODO: use SlotName in ladder (new addition) instead of this
         public List<RoundBeatmap> Pool
         {
             set

--- a/osu.Game.Tournament/Components/TournamentBeatmapPanel.cs
+++ b/osu.Game.Tournament/Components/TournamentBeatmapPanel.cs
@@ -25,6 +25,7 @@ namespace osu.Game.Tournament.Components
         private readonly string mod;
 
         public const float HEIGHT = 50;
+        public const float WIDTH = 400;
 
         private readonly Bindable<TournamentMatch?> currentMatch = new Bindable<TournamentMatch?>();
 
@@ -35,7 +36,7 @@ namespace osu.Game.Tournament.Components
             Beatmap = beatmap;
             this.mod = mod;
 
-            Width = 400;
+            Width = WIDTH;
             Height = HEIGHT;
         }
 

--- a/osu.Game.Tournament/Components/TournamentSetPanel.cs
+++ b/osu.Game.Tournament/Components/TournamentSetPanel.cs
@@ -210,6 +210,8 @@ namespace osu.Game.Tournament.Components
             }
         }
 
+        public MatchSet Model { get; init; }
+
         public const float HEIGHT = TournamentBeatmapPanel.HEIGHT;
         public const float WIDTH = TournamentBeatmapPanel.WIDTH;
 
@@ -231,14 +233,10 @@ namespace osu.Game.Tournament.Components
         private SetMapResultDisplay map1ResultDisplay = null!;
         private SetMapResultDisplay map2ResultDisplay = null!;
 
-        private readonly BindableList<SetMapResultDisplay> mapResults = new BindableList<SetMapResultDisplay>();
-        public IBindableList<SetMapResultDisplay> MapResults => mapResults; // does this need to be a bindable list?
-
-        public BindableLong Map1Id = new BindableLong();
-        public BindableLong Map2Id = new BindableLong();
-
-        public TournamentSetPanel()
+        public TournamentSetPanel(MatchSet set)
         {
+            Model = set;
+
             Width = WIDTH;
             Height = HEIGHT;
             Masking = true;
@@ -286,14 +284,11 @@ namespace osu.Game.Tournament.Components
                 }
             });
 
-            // mapResults.Add(map1Result);
-            // mapResults.Add(map2Result);
-
-            Map1Id.BindValueChanged(vce =>
+            Model.Map1Id.BindValueChanged(vce =>
             {
                 map1ResultDisplay.MapID = vce.NewValue;
             }, true);
-            Map2Id.BindValueChanged(vce =>
+            Model.Map2Id.BindValueChanged(vce =>
             {
                 map2ResultDisplay.MapID = vce.NewValue;
             }, true);

--- a/osu.Game.Tournament/Components/TournamentSetPanel.cs
+++ b/osu.Game.Tournament/Components/TournamentSetPanel.cs
@@ -1,0 +1,271 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Logging;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Tournament.Models;
+using osu.Game.Tournament.Screens.Ladder.Components;
+using osuTK.Graphics;
+
+namespace osu.Game.Tournament.Components
+{
+    public partial class TournamentSetPanel : CompositeDrawable
+    {
+        private partial class SetMapScoreCounter : DrawableMatchTeam.MatchTeamCumulativeScoreCounter
+        {
+            protected override OsuSpriteText CreateSpriteText() => base.CreateSpriteText().With(s =>
+            {
+                DisplayedSpriteText = s;
+                DisplayedSpriteText.Font = OsuFont.Torus.With(size: 16);
+            });
+        }
+
+        private partial class SetMapResult : CompositeDrawable
+        {
+            public readonly IBindable<long?> Player1Score = new Bindable<long?>();
+            public readonly IBindable<long?> Player2Score = new Bindable<long?>();
+
+            private SetMapScoreCounter p1ScoreCounter = null!;
+            private SetMapScoreCounter p2ScoreCounter = null!;
+
+            public SetMapResult()
+            {
+                Height = 32;
+                Anchor = Anchor.CentreLeft;
+                Origin = Anchor.CentreLeft;
+            }
+
+            [BackgroundDependencyLoader]
+            private void load()
+            {
+                InternalChildren = new Drawable[]
+                {
+                    new Container
+                    {
+                        Width = 0.3f,
+                        RelativeSizeAxes = Axes.Both,
+                        Child = new TournamentSpriteText
+                        {
+                            Origin = Anchor.Centre,
+                            Anchor = Anchor.Centre,
+                            Text = "NM1",
+                            Font = OsuFont.Torus.With(weight: FontWeight.Bold, size: 22),
+                        },
+                    },
+                    new Container
+                    {
+                        Masking = true,
+                        Width = 0.35f,
+                        Anchor = Anchor.CentreLeft,
+                        Origin = Anchor.CentreLeft,
+                        RelativeSizeAxes = Axes.Both,
+                        RelativePositionAxes = Axes.X,
+                        X = 0.3f,
+                        Children = new Drawable[]
+                        {
+                            // new Box
+                            // {
+                            //     Colour = OsuColour.Gray(0.1f),
+                            //     Alpha = 0.8f,
+                            //     RelativeSizeAxes = Axes.Both,
+                            // },
+                            p1ScoreCounter = new SetMapScoreCounter
+                            {
+                                Anchor = Anchor.Centre,
+                                Origin = Anchor.Centre,
+                            },
+                        }
+                    },
+                    new Container
+                    {
+                        Masking = true,
+                        Width = 0.35f,
+                        Anchor = Anchor.CentreLeft,
+                        Origin = Anchor.CentreLeft,
+                        RelativeSizeAxes = Axes.Both,
+                        RelativePositionAxes = Axes.X,
+                        X = 0.65f,
+                        Children = new Drawable[]
+                        {
+                            p2ScoreCounter = new SetMapScoreCounter
+                            {
+                                Anchor = Anchor.Centre,
+                                Origin = Anchor.Centre,
+                            },
+                        }
+                    }
+                };
+
+                Player1Score.BindValueChanged(val => updatePlayerScore(p1ScoreCounter, val), true);
+                Player2Score.BindValueChanged(val => updatePlayerScore(p2ScoreCounter, val), true);
+
+                // testing code, remove!!!
+                {
+                    var a = new Bindable<long?>();
+                    var b = new Bindable<long?>();
+
+                    Player1Score.BindTo(a);
+                    Player2Score.BindTo(b);
+
+                    a.Value = Random.Shared.NextInt64() % 1_200_000;
+                    b.Value = Random.Shared.NextInt64() % 1_200_000;
+                }
+
+                void updatePlayerScore(SetMapScoreCounter counter, ValueChangedEvent<long?> changeEvent)
+                {
+                    switch (changeEvent.NewValue)
+                    {
+                        case 0:
+                        case null:
+                            counter.DisplayedSpriteText.Text = changeEvent.NewValue?.ToString() ?? "0";
+                            break;
+
+                        default:
+                            counter.Current.Value = (double)changeEvent.NewValue;
+                            break;
+                    }
+                }
+            }
+        }
+
+        public float HEIGHT = TournamentBeatmapPanel.HEIGHT;
+        public float WIDTH = TournamentBeatmapPanel.WIDTH;
+
+        private TeamColour? winnerColour = null;
+
+        public TeamColour? Winner
+        {
+            get => winnerColour;
+            set
+            {
+                winnerColour = value;
+                updateWinState();
+            }
+        }
+
+        public readonly BindableList<TournamentBeatmapPanel> BeatmapPanels = new BindableList<TournamentBeatmapPanel>();
+
+        public TournamentSetPanel()
+        {
+            Width = WIDTH;
+            Height = HEIGHT;
+            Masking = true;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            AddRangeInternal(new Drawable[]
+            {
+                new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Colour = Color4.Black,
+                    Alpha = 0.35f,
+                },
+                // new FillFlowContainer
+                // {
+                //     AutoSizeAxes = Axes.Both,
+                //     Anchor = Anchor.TopCentre,
+                //     Origin = Anchor.TopCentre,
+                //     Padding = new MarginPadding(15),
+                //     Spacing = new Vector2(15),
+                //     Direction = FillDirection.Horizontal,
+                //     Children = new Drawable[]
+                //     {
+                //         new TournamentSpriteText
+                //         {
+                //             Text = "aba",
+                //             Font = OsuFont.Torus.With(weight: FontWeight.Bold),
+                //         },
+                //         new TournamentSpriteText
+                //         {
+                //             Text = "aboba",
+                //             Font = OsuFont.Torus.With(weight: FontWeight.Bold),
+                //         },
+                //     }
+                // },
+                new GridContainer
+                {
+                    Name = "slots",
+                    // Margin = new MarginPadding { Top = main_content_height },
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    Padding = new MarginPadding(5),
+                    Anchor = Anchor.CentreLeft,
+                    Origin = Anchor.CentreLeft,
+                    ColumnDimensions = new[]
+                    {
+                        new Dimension(),
+                        new Dimension()
+                    },
+                    RowDimensions = new[] { new Dimension() },
+                    Content = new[]
+                    {
+                        new Drawable[]
+                        {
+                            // new TournamentSpriteText
+                            // {
+                            //     Origin = Anchor.Centre,
+                            //     Anchor = Anchor.Centre,
+                            //     Text = "NM1",
+                            //     Font = OsuFont.Torus.With(weight: FontWeight.Bold),
+                            // },
+                            // new TournamentSpriteText
+                            // {
+                            //     Origin = Anchor.Centre,
+                            //     Anchor = Anchor.Centre,
+                            //     Text = "NM2",
+                            //     Font = OsuFont.Torus.With(weight: FontWeight.Bold),
+                            // },
+                            new SetMapResult
+                            {
+                                RelativeSizeAxes = Axes.X,
+                            },
+                            new SetMapResult
+                            {
+                                RelativeSizeAxes = Axes.X,
+                            }
+                        }
+                    }
+                }
+            });
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            BeatmapPanels.BindCollectionChanged((sender, args) =>
+            {
+                Logger.Log($"TournamentSetPanel beatmap panels collection changed: {args.NewItems}");
+            });
+        }
+
+        /// <summary>
+        /// Add/remove colored border depending on winner
+        /// </summary>
+        private void updateWinState()
+        {
+            if (winnerColour != null)
+            {
+                BorderThickness = 6;
+
+                BorderColour = TournamentGame.GetTeamColour((TeamColour)winnerColour);
+            }
+            else
+            {
+                Colour = Color4.White;
+                BorderThickness = 0;
+                Alpha = 1;
+            }
+        }
+    }
+}

--- a/osu.Game.Tournament/Components/TournamentSetPanel.cs
+++ b/osu.Game.Tournament/Components/TournamentSetPanel.cs
@@ -29,8 +29,9 @@ namespace osu.Game.Tournament.Components
 
         public partial class SetMapResult : CompositeDrawable
         {
-            public readonly IBindable<long?> Player1Score = new Bindable<long?>();
-            public readonly IBindable<long?> Player2Score = new Bindable<long?>();
+            // todo: make these private?
+            public readonly Bindable<long?> Player1Score = new Bindable<long?>();
+            public readonly Bindable<long?> Player2Score = new Bindable<long?>();
 
             private TournamentSpriteText slotText = null!;
             private long mapId = 0;
@@ -79,6 +80,20 @@ namespace osu.Game.Tournament.Components
                 slotText.Text = poolMap?.SlotName ?? "??";
 
                 Logger.Log($"Setting mapid for {TestName}: {poolMap}");
+
+                CurrentMatch.Value.MapScores.BindCollectionChanged((_, args) =>
+                {
+                    if (args.NewItems == null)
+                        return;
+
+                    foreach ((string key, var value) in args.NewItems)
+                    {
+                        if (key != slotText.Text) continue;
+
+                        Player1Score.Value = value.Item1;
+                        Player2Score.Value = value.Item2;
+                    }
+                });
             }
 
             public readonly string TestName = "";
@@ -148,7 +163,6 @@ namespace osu.Game.Tournament.Components
                     }
                 };
 
-                // todo: bind score to something...?
                 Player1Score.BindValueChanged(val => updatePlayerScore(p1ScoreCounter, val), true);
                 Player2Score.BindValueChanged(val => updatePlayerScore(p2ScoreCounter, val), true);
 

--- a/osu.Game.Tournament/Models/LadderInfo.cs
+++ b/osu.Game.Tournament/Models/LadderInfo.cs
@@ -66,6 +66,9 @@ namespace osu.Game.Tournament.Models
 
         public Bindable<bool> DisplayTeamSeeds = new BindableBool();
 
+        /// <summary>
+        /// Now used for set cumulative scoring
+        /// </summary>
         public Bindable<bool> CumulativeScore = new BindableBool();
     }
 }

--- a/osu.Game.Tournament/Models/MatchSet.cs
+++ b/osu.Game.Tournament/Models/MatchSet.cs
@@ -1,0 +1,13 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Bindables;
+
+namespace osu.Game.Tournament.Models
+{
+    public class MatchSet
+    {
+        public BindableLong Map1Id = new BindableLong();
+        public BindableLong Map2Id = new BindableLong();
+    }
+}

--- a/osu.Game.Tournament/Models/MatchSet.cs
+++ b/osu.Game.Tournament/Models/MatchSet.cs
@@ -1,13 +1,64 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using System.Linq;
 using osu.Framework.Bindables;
 
 namespace osu.Game.Tournament.Models
 {
     public class MatchSet
     {
+        // TODO: set scores should really be stored in MatchSet instead of in TournamentMatch
+
         public BindableLong Map1Id = new BindableLong();
         public BindableLong Map2Id = new BindableLong();
+
+        public static MatchSet? FindSetByMapId(TournamentMatch match, long mapId)
+        {
+            return match.Sets.FirstOrDefault(s => s.Map1Id.Value == mapId || s.Map2Id.Value == mapId);
+        }
+
+        public Tuple<long, long>? GetSetScores(TournamentMatch currentMatch)
+        {
+            // lookup roundbeatmap
+            var map1RoundBeatmap = currentMatch.Round.Value?.Beatmaps.FirstOrDefault(poolMap => poolMap.ID == Map1Id.Value);
+            var map2RoundBeatmap = currentMatch.Round.Value?.Beatmaps.FirstOrDefault(poolMap => poolMap.ID == Map2Id.Value);
+
+            if (map1RoundBeatmap == null && map2RoundBeatmap == null)
+                return null;
+
+            // get scores from both maps
+            long scoreRed = 0;
+            long scoreBlue = 0;
+
+            if (currentMatch.MapScores.TryGetValue(map1RoundBeatmap?.SlotName ?? "INVALID_SLOT", out var map1Score))
+            {
+                scoreRed += map1Score.Item1;
+                scoreBlue += map1Score.Item2;
+            }
+
+            if (currentMatch.MapScores.TryGetValue(map2RoundBeatmap?.SlotName ?? "INVALID_SLOT", out var map2Score))
+            {
+                scoreRed += map2Score.Item1;
+                scoreBlue += map2Score.Item2;
+            }
+
+            return new Tuple<long, long>(scoreRed, scoreBlue);
+        }
+
+        /// <summary>
+        /// Helper to get the set scores for both players.
+        /// </summary>
+        /// <param name="currentMatch"></param>
+        /// <param name="mapId"></param>
+        /// <returns></returns>
+        public static Tuple<long, long>? GetSetScores(TournamentMatch currentMatch, long mapId)
+        {
+            // get the current set
+            var currentSet = FindSetByMapId(currentMatch, mapId);
+
+            return currentSet?.GetSetScores(currentMatch);
+        }
     }
 }

--- a/osu.Game.Tournament/Models/MatchSet.cs
+++ b/osu.Game.Tournament/Models/MatchSet.cs
@@ -13,10 +13,17 @@ namespace osu.Game.Tournament.Models
 
         public BindableLong Map1Id = new BindableLong();
         public BindableLong Map2Id = new BindableLong();
+        public BindableLong Map3Id = new BindableLong();
+        public readonly bool IsTiebreaker;
+
+        public MatchSet(bool isTiebreaker)
+        {
+            IsTiebreaker = isTiebreaker;
+        }
 
         public static MatchSet? FindSetByMapId(TournamentMatch match, long mapId)
         {
-            return match.Sets.FirstOrDefault(s => s.Map1Id.Value == mapId || s.Map2Id.Value == mapId);
+            return match.Sets.FirstOrDefault(s => s.Map1Id.Value == mapId || s.Map2Id.Value == mapId || s.Map3Id.Value == mapId);
         }
 
         public Tuple<long, long>? GetSetScores(TournamentMatch currentMatch)
@@ -24,6 +31,7 @@ namespace osu.Game.Tournament.Models
             // lookup roundbeatmap
             var map1RoundBeatmap = currentMatch.Round.Value?.Beatmaps.FirstOrDefault(poolMap => poolMap.ID == Map1Id.Value);
             var map2RoundBeatmap = currentMatch.Round.Value?.Beatmaps.FirstOrDefault(poolMap => poolMap.ID == Map2Id.Value);
+            var map3RoundBeatmap = currentMatch.Round.Value?.Beatmaps.FirstOrDefault(poolMap => poolMap.ID == Map3Id.Value);
 
             if (map1RoundBeatmap == null && map2RoundBeatmap == null)
                 return null;
@@ -42,6 +50,12 @@ namespace osu.Game.Tournament.Models
             {
                 scoreRed += map2Score.Item1;
                 scoreBlue += map2Score.Item2;
+            }
+
+            if (currentMatch.MapScores.TryGetValue(map3RoundBeatmap?.SlotName ?? "INVALID_SLOT", out var map3Score))
+            {
+                scoreRed += map3Score.Item1;
+                scoreBlue += map3Score.Item2;
             }
 
             return new Tuple<long, long>(scoreRed, scoreBlue);

--- a/osu.Game.Tournament/Models/RoundBeatmap.cs
+++ b/osu.Game.Tournament/Models/RoundBeatmap.cs
@@ -10,6 +10,7 @@ namespace osu.Game.Tournament.Models
         public int ID;
         public string MD5 = string.Empty;
         public string Mods = string.Empty;
+        public string SlotName = string.Empty;
 
         [JsonProperty("BeatmapInfo")]
         public TournamentBeatmap? Beatmap;

--- a/osu.Game.Tournament/Models/TournamentMatch.cs
+++ b/osu.Game.Tournament/Models/TournamentMatch.cs
@@ -51,6 +51,8 @@ namespace osu.Game.Tournament.Models
 
         public readonly ObservableCollection<BeatmapChoice> PicksBans = new ObservableCollection<BeatmapChoice>();
 
+        public readonly BindableDictionary<string, Tuple<long, long>> MapScores = new BindableDictionary<string, Tuple<long, long>>();
+
         [JsonIgnore]
         public readonly Bindable<TournamentRound?> Round = new Bindable<TournamentRound?>();
 

--- a/osu.Game.Tournament/Models/TournamentMatch.cs
+++ b/osu.Game.Tournament/Models/TournamentMatch.cs
@@ -51,6 +51,8 @@ namespace osu.Game.Tournament.Models
 
         public readonly ObservableCollection<BeatmapChoice> PicksBans = new ObservableCollection<BeatmapChoice>();
 
+        public readonly ObservableCollection<MatchSet> Sets = new ObservableCollection<MatchSet>();
+
         public readonly BindableDictionary<string, Tuple<long, long>> MapScores = new BindableDictionary<string, Tuple<long, long>>();
 
         [JsonIgnore]

--- a/osu.Game.Tournament/Screens/Editors/RoundEditorScreen.cs
+++ b/osu.Game.Tournament/Screens/Editors/RoundEditorScreen.cs
@@ -172,6 +172,30 @@ namespace osu.Game.Tournament.Screens.Editors
                 AutoSizeAxes = Axes.Y;
             }
 
+            protected override void LoadComplete()
+            {
+                base.LoadComplete();
+
+                Model.Beatmaps.BindCollectionChanged((_, _) =>
+                {
+                    // recompute mod slots
+                    string? currentMods = null;
+                    int modSlotIndex = 1;
+
+                    foreach (var b in Model.Beatmaps)
+                    {
+                        if (currentMods != b.Mods)
+                        {
+                            currentMods = b.Mods;
+                            modSlotIndex = 1;
+                        }
+
+                        b.SlotName = currentMods == "TB" ? currentMods : $"{currentMods}{modSlotIndex}";
+                        modSlotIndex++;
+                    }
+                }, true);
+            }
+
             public partial class RoundBeatmapEditor : CompositeDrawable
             {
                 private readonly TournamentRound round;

--- a/osu.Game.Tournament/Screens/Gameplay/Components/MatchHeader.cs
+++ b/osu.Game.Tournament/Screens/Gameplay/Components/MatchHeader.cs
@@ -143,6 +143,7 @@ namespace osu.Game.Tournament.Screens.Gameplay.Components
                             Anchor = Anchor.TopCentre,
                             Origin = Anchor.TopCentre,
                             Spacing = new Vector2(16),
+                            Margin = new MarginPadding { Top = 16 },
                             Children = new Drawable[]
                             {
                                 leftWinningTriangle = new SpriteIcon

--- a/osu.Game.Tournament/Screens/Gameplay/Components/MatchHeader.cs
+++ b/osu.Game.Tournament/Screens/Gameplay/Components/MatchHeader.cs
@@ -198,7 +198,7 @@ namespace osu.Game.Tournament.Screens.Gameplay.Components
 
                 var scores = MatchSet.FindSetByMapId(ladder.CurrentMatch.Value, mapId)?.GetSetScores(ladder.CurrentMatch.Value);
 
-                return scores != null ? Math.Abs(scores.Item1 - scores.Item2) : 0;
+                return scores != null ? scores.Item1 - scores.Item2 : 0;
             }
         }
 

--- a/osu.Game.Tournament/Screens/Gameplay/Components/MatchHeader.cs
+++ b/osu.Game.Tournament/Screens/Gameplay/Components/MatchHeader.cs
@@ -39,6 +39,7 @@ namespace osu.Game.Tournament.Screens.Gameplay.Components
         private TeamScoreDisplay teamDisplay1 = null!;
         private TeamScoreDisplay teamDisplay2 = null!;
         private DrawableTournamentHeaderLogo logo = null!;
+        private MatchRoundDisplay roundDisplay = null!;
         private MatchCumulativeScoreDiffCounter cumulativeScoreDiffCounter = null!;
         private FillFlowContainer cumulativeScoreDiffCounterContainer = null!;
         private readonly Bindable<TournamentMatch?> currentMatch = new Bindable<TournamentMatch?>();
@@ -83,6 +84,24 @@ namespace osu.Game.Tournament.Screens.Gameplay.Components
             }
         }
 
+        private bool showMatchRound = true;
+
+        public bool ShowMatchRound
+        {
+            get => showMatchRound;
+
+            set
+            {
+                if (value == showMatchRound)
+                    return;
+
+                showMatchRound = value;
+
+                if (IsLoaded)
+                    updateDisplay();
+            }
+        }
+
         [BackgroundDependencyLoader]
         private void load(LadderInfo ladder)
         {
@@ -112,7 +131,7 @@ namespace osu.Game.Tournament.Screens.Gameplay.Components
                             Anchor = Anchor.TopCentre,
                             Origin = Anchor.TopCentre,
                         },
-                        new MatchRoundDisplay
+                        roundDisplay = new MatchRoundDisplay
                         {
                             Anchor = Anchor.TopCentre,
                             Origin = Anchor.TopCentre,
@@ -238,6 +257,7 @@ namespace osu.Game.Tournament.Screens.Gameplay.Components
             cumulativeScoreDiffCounterContainer.FadeTo(showScores && useCumulativeScore.Value ? 1 : 0, 200);
 
             logo.Alpha = showLogo ? 1 : 0;
+            roundDisplay.Alpha = showMatchRound ? 1 : 0;
         }
     }
 }

--- a/osu.Game.Tournament/Screens/Gameplay/Components/TeamDisplay.cs
+++ b/osu.Game.Tournament/Screens/Gameplay/Components/TeamDisplay.cs
@@ -111,7 +111,7 @@ namespace osu.Game.Tournament.Screens.Gameplay.Components
                                     },
                                 }
                             },
-                            teamScoreCumulative = new TeamScoreCumulative
+                            teamScoreCumulative = new TeamScoreCumulative(colour)
                             {
                                 Origin = anchor,
                                 Anchor = anchor,
@@ -120,10 +120,6 @@ namespace osu.Game.Tournament.Screens.Gameplay.Components
                     },
                 }
             };
-            currentTeamScore.BindValueChanged(_ =>
-            {
-                teamScoreCumulative.Current.Value = currentTeamScore.Value ?? 0;
-            }, true);
         }
 
         protected override void LoadComplete()

--- a/osu.Game.Tournament/Screens/Gameplay/Components/TeamDisplay.cs
+++ b/osu.Game.Tournament/Screens/Gameplay/Components/TeamDisplay.cs
@@ -97,12 +97,30 @@ namespace osu.Game.Tournament.Screens.Gameplay.Components
                                             }
                                         }
                                     },
-                                    teamNameText = new TournamentSpriteTextWithBackground
+                                    new FillFlowContainer
                                     {
-                                        Scale = new Vector2(0.5f),
+                                        AutoSizeAxes = Axes.Both,
+                                        Direction = FillDirection.Horizontal,
+                                        Spacing = new Vector2(5),
                                         Origin = anchor,
                                         Anchor = anchor,
+                                        Children = new Drawable[]
+                                        {
+                                            teamNameText = new TournamentSpriteTextWithBackground
+                                            {
+                                                Scale = new Vector2(0.5f),
+                                                Origin = anchor,
+                                                Anchor = anchor,
+                                            },
+                                            teamScoreCumulative = new TeamScoreCumulative(colour)
+                                            {
+                                                Origin = anchor,
+                                                Anchor = anchor,
+                                                Margin = new MarginPadding { Horizontal = 12 },
+                                            },
+                                        }
                                     },
+
                                     new DrawableTeamSeed(Team)
                                     {
                                         Scale = new Vector2(0.5f),
@@ -110,11 +128,6 @@ namespace osu.Game.Tournament.Screens.Gameplay.Components
                                         Anchor = anchor,
                                     },
                                 }
-                            },
-                            teamScoreCumulative = new TeamScoreCumulative(colour)
-                            {
-                                Origin = anchor,
-                                Anchor = anchor,
                             },
                         }
                     },

--- a/osu.Game.Tournament/Screens/Gameplay/Components/TeamDisplay.cs
+++ b/osu.Game.Tournament/Screens/Gameplay/Components/TeamDisplay.cs
@@ -1,13 +1,9 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Game.Graphics;
-using osu.Game.Graphics.Sprites;
-using osu.Game.Graphics.UserInterface;
 using osu.Game.Tournament.Components;
 using osu.Game.Tournament.Models;
 using osuTK;
@@ -16,39 +12,9 @@ namespace osu.Game.Tournament.Screens.Gameplay.Components
 {
     public partial class TeamDisplay : DrawableTournamentTeam
     {
-        protected partial class MatchCumulativeScoreCounter : CommaSeparatedScoreCounter
-        {
-            private OsuSpriteText displayedSpriteText = null!;
-            private const int font_size = 50;
-            private Bindable<bool> useCumulativeScore = null!;
-
-            [Resolved]
-            private LadderInfo ladder { get; set; } = null!;
-
-            public MatchCumulativeScoreCounter()
-            {
-                Margin = new MarginPadding(8);
-            }
-
-            protected override void LoadComplete()
-            {
-                base.LoadComplete();
-
-                useCumulativeScore = ladder.CumulativeScore.GetBoundCopy();
-                useCumulativeScore.BindValueChanged(v => displayedSpriteText.Alpha = v.NewValue ? 1 : 0, true);
-            }
-
-            protected override OsuSpriteText CreateSpriteText() => base.CreateSpriteText().With(s =>
-            {
-                displayedSpriteText = s;
-                displayedSpriteText.Spacing = new Vector2(-6);
-                displayedSpriteText.Font = OsuFont.Torus.With(weight: FontWeight.SemiBold, size: font_size, fixedWidth: true);
-            });
-        }
-
         private readonly TeamScore score;
 
-        private readonly MatchCumulativeScoreCounter cumulativeScoreCounter;
+        private readonly TeamScoreCumulative teamScoreCumulative;
 
         private readonly TournamentSpriteTextWithBackground teamNameText;
 
@@ -145,7 +111,7 @@ namespace osu.Game.Tournament.Screens.Gameplay.Components
                                     },
                                 }
                             },
-                            cumulativeScoreCounter = new MatchCumulativeScoreCounter
+                            teamScoreCumulative = new TeamScoreCumulative
                             {
                                 Origin = anchor,
                                 Anchor = anchor,
@@ -156,7 +122,7 @@ namespace osu.Game.Tournament.Screens.Gameplay.Components
             };
             currentTeamScore.BindValueChanged(_ =>
             {
-                cumulativeScoreCounter.Current.Value = currentTeamScore.Value ?? 0;
+                teamScoreCumulative.Current.Value = currentTeamScore.Value ?? 0;
             }, true);
         }
 
@@ -176,7 +142,7 @@ namespace osu.Game.Tournament.Screens.Gameplay.Components
         private void updateDisplay()
         {
             score.FadeTo(ShowScore ? 1 : 0, 200);
-            cumulativeScoreCounter.FadeTo(ShowScore ? 1 : 0, 200);
+            teamScoreCumulative.FadeTo(ShowScore ? 1 : 0, 200);
         }
     }
 }

--- a/osu.Game.Tournament/Screens/Gameplay/Components/TeamScore.cs
+++ b/osu.Game.Tournament/Screens/Gameplay/Components/TeamScore.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
@@ -20,10 +19,6 @@ namespace osu.Game.Tournament.Screens.Gameplay.Components
     {
         private readonly Bindable<long?> currentTeamScore = new Bindable<long?>();
         private readonly StarCounter counter;
-        private Bindable<bool> useCumulativeScore = null!;
-
-        [Resolved]
-        private LadderInfo ladder { get; set; } = null!;
 
         public TeamScore(Bindable<long?> score, TeamColour colour, int count)
         {
@@ -40,14 +35,6 @@ namespace osu.Game.Tournament.Screens.Gameplay.Components
 
             currentTeamScore.BindValueChanged(scoreChanged);
             currentTeamScore.BindTo(score);
-        }
-
-        protected override void LoadComplete()
-        {
-            base.LoadComplete();
-
-            useCumulativeScore = ladder.CumulativeScore.GetBoundCopy();
-            useCumulativeScore.BindValueChanged(v => counter.Alpha = v.NewValue ? 0 : 1, true);
         }
 
         private void scoreChanged(ValueChangedEvent<long?> score) => counter.Current = score.NewValue ?? 0;

--- a/osu.Game.Tournament/Screens/Gameplay/Components/TeamScoreCumulative.cs
+++ b/osu.Game.Tournament/Screens/Gameplay/Components/TeamScoreCumulative.cs
@@ -31,8 +31,6 @@ namespace osu.Game.Tournament.Screens.Gameplay.Components
 
         public TeamScoreCumulative(TeamColour colour)
         {
-            Margin = new MarginPadding(8);
-
             teamColour = colour;
         }
 

--- a/osu.Game.Tournament/Screens/Gameplay/Components/TeamScoreCumulative.cs
+++ b/osu.Game.Tournament/Screens/Gameplay/Components/TeamScoreCumulative.cs
@@ -1,18 +1,22 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
+using osu.Framework.Logging;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Tournament.IPC;
 using osu.Game.Tournament.Models;
 using osuTK;
 
 namespace osu.Game.Tournament.Screens.Gameplay.Components
 {
-    public partial class TeamScoreCumulative : CommaSeparatedScoreCounter
+    public partial class TeamScoreCumulative : CommaSeparatedScoreCounter<long>
     {
         private OsuSpriteText displayedSpriteText = null!;
         private const int font_size = 50;
@@ -21,9 +25,29 @@ namespace osu.Game.Tournament.Screens.Gameplay.Components
         [Resolved]
         private LadderInfo ladder { get; set; } = null!;
 
-        public TeamScoreCumulative()
+        private readonly BindableDictionary<string,Tuple<long,long>> mapScores = new BindableDictionary<string, Tuple<long, long>>();
+        private readonly IBindable<TournamentBeatmap?> beatmap = new Bindable<TournamentBeatmap?>();
+        private readonly TeamColour teamColour;
+
+        public TeamScoreCumulative(TeamColour colour)
         {
             Margin = new MarginPadding(8);
+
+            teamColour = colour;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(LegacyMatchIPCInfo legacyIpc, MatchIPCInfo lazerIpc)
+        {
+            ladder.UseLazerIpc.BindValueChanged(
+                vce =>
+                {
+                    beatmap.UnbindAll();
+                    beatmap.BindTo(vce.NewValue ? lazerIpc.Beatmap : legacyIpc.Beatmap);
+                },
+                true);
+
+            beatmap.BindValueChanged(_ => updateCumulativeScore(), true);
         }
 
         protected override void LoadComplete()
@@ -32,6 +56,68 @@ namespace osu.Game.Tournament.Screens.Gameplay.Components
 
             useCumulativeScore = ladder.CumulativeScore.GetBoundCopy();
             useCumulativeScore.BindValueChanged(v => displayedSpriteText.Alpha = v.NewValue ? 1 : 0, true);
+
+            ladder.CurrentMatch.BindValueChanged(vce =>
+            {
+                mapScores.UnbindBindings();
+
+                if (vce.NewValue == null)
+                    return;
+
+                mapScores.BindTo(vce.NewValue.MapScores);
+            }, true);
+
+            mapScores.BindCollectionChanged((_, e) =>
+            {
+                if (e.NewItems != null)
+                    Logger.Log($"mapScores changed: {string.Join(",", e.NewItems.Select(i => i.Key))}");
+
+                updateCumulativeScore();
+            }, true);
+        }
+
+        private void updateCumulativeScore()
+        {
+            // if (ladder.CurrentMatch.Value?.Round.Value == null)
+            //     return;
+            //
+            // if (beatmap.Value == null)
+            //     return;
+            //
+            // // get the current set
+            // var currentSet = ladder.CurrentMatch.Value.Sets.FirstOrDefault(s => s.Map1Id.Value == beatmap.Value.OnlineID || s.Map2Id.Value == beatmap.Value.OnlineID);
+            //
+            // if (currentSet == null)
+            //     return;
+            //
+            // // lookup roundbeatmap
+            // var map1RoundBeatmap = ladder.CurrentMatch.Value.Round.Value?.Beatmaps.FirstOrDefault(poolMap => poolMap.ID == currentSet.Map1Id.Value);
+            // var map2RoundBeatmap = ladder.CurrentMatch.Value.Round.Value?.Beatmaps.FirstOrDefault(poolMap => poolMap.ID == currentSet.Map2Id.Value);
+            //
+            // if (map1RoundBeatmap == null && map2RoundBeatmap == null)
+            //     return;
+            //
+            // // get scores from both maps
+            // long score = 0;
+            //
+            // if (ladder.CurrentMatch.Value.MapScores.TryGetValue(map1RoundBeatmap?.SlotName ?? "INVALID_SLOT", out var map1Score))
+            //     score += teamColour == TeamColour.Red ? map1Score.Item1 : map1Score.Item2;
+            //
+            // if (ladder.CurrentMatch.Value.MapScores.TryGetValue(map2RoundBeatmap?.SlotName ?? "INVALID_SLOT", out var map2Score))
+            //     score += teamColour == TeamColour.Red ? map2Score.Item1 : map2Score.Item2;
+
+            if (ladder.CurrentMatch.Value?.Round.Value == null)
+                return;
+
+            if (beatmap.Value == null)
+                return;
+
+            var scores = MatchSet.GetSetScores(ladder.CurrentMatch.Value, beatmap.Value.OnlineID);
+
+            if (scores == null)
+                return;
+
+            Current.Value = teamColour == TeamColour.Red ? scores.Item1 : scores.Item2;
         }
 
         protected override OsuSpriteText CreateSpriteText() => base.CreateSpriteText().With(s =>

--- a/osu.Game.Tournament/Screens/Gameplay/Components/TeamScoreCumulative.cs
+++ b/osu.Game.Tournament/Screens/Gameplay/Components/TeamScoreCumulative.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Tournament.Models;
+using osuTK;
+
+namespace osu.Game.Tournament.Screens.Gameplay.Components
+{
+    public partial class TeamScoreCumulative : CommaSeparatedScoreCounter
+    {
+        private OsuSpriteText displayedSpriteText = null!;
+        private const int font_size = 50;
+        private Bindable<bool> useCumulativeScore = null!;
+
+        [Resolved]
+        private LadderInfo ladder { get; set; } = null!;
+
+        public TeamScoreCumulative()
+        {
+            Margin = new MarginPadding(8);
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            useCumulativeScore = ladder.CumulativeScore.GetBoundCopy();
+            useCumulativeScore.BindValueChanged(v => displayedSpriteText.Alpha = v.NewValue ? 1 : 0, true);
+        }
+
+        protected override OsuSpriteText CreateSpriteText() => base.CreateSpriteText().With(s =>
+        {
+            displayedSpriteText = s;
+            displayedSpriteText.Spacing = new Vector2(-6);
+            displayedSpriteText.Font = OsuFont.Torus.With(weight: FontWeight.SemiBold, size: font_size, fixedWidth: true);
+        });
+    }
+}

--- a/osu.Game.Tournament/Screens/Gameplay/GameplayScreen.cs
+++ b/osu.Game.Tournament/Screens/Gameplay/GameplayScreen.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -262,31 +263,38 @@ namespace osu.Game.Tournament.Screens.Gameplay
 
                     if (LadderInfo.CumulativeScore.Value)
                     {
-                        CurrentMatch.Value.Team1Score.Value += lazerIpc.Score1.Value;
-                        CurrentMatch.Value.Team2Score.Value += lazerIpc.Score2.Value;
+                        // CurrentMatch.Value.Team1Score.Value += lazerIpc.Score1.Value;
+                        // CurrentMatch.Value.Team2Score.Value += lazerIpc.Score2.Value;
 
                         int mapId = lazerIpc.Beatmap.Value?.OnlineID ?? 0;
 
                         if (mapId > 0)
                         {
-                            int pickBansCount = LadderInfo.CurrentMatch.Value?.PicksBans.Count ?? 0;
-                            int poolSize = LadderInfo.CurrentMatch.Value?.Round.Value?.Beatmaps.Count ?? -1;
+                            // int pickBansCount = LadderInfo.CurrentMatch.Value?.PicksBans.Count ?? 0;
+                            // int poolSize = LadderInfo.CurrentMatch.Value?.Round.Value?.Beatmaps.Count ?? -1;
+                            //
+                            // bool eligibleForWin = pickBansCount + 1 == poolSize;
+                            //
+                            // Logger.Log($"{nameof(updateStateLazer)}: pickban#: {pickBansCount} | poolSize: {poolSize} | can win?: {eligibleForWin}");
+                            //
+                            // if (eligibleForWin)
+                            // {
+                            //     // we have a decider map
+                            //     var deciderMap = CurrentMatch.Value.Round.Value?.Beatmaps
+                            //                                  .FirstOrDefault(b => CurrentMatch.Value.PicksBans.All(p => p.BeatmapID != b.ID));
+                            //
+                            //     Logger.Log($"{nameof(updateStateLazer)}: on decider map?: {deciderMap != null}");
+                            //
+                            //     // mark match as completed, as we've played the decider map
+                            //     if (deciderMap?.ID == mapId)
+                            //         CurrentMatch.Value.Completed.Value = true;
+                            // }
 
-                            bool eligibleForWin = pickBansCount + 1 == poolSize;
+                            var roundMap = CurrentMatch.Value.Round.Value?.Beatmaps.FirstOrDefault(b => b.ID == mapId);
 
-                            Logger.Log($"{nameof(updateStateLazer)}: pickban#: {pickBansCount} | poolSize: {poolSize} | can win?: {eligibleForWin}");
-
-                            if (eligibleForWin)
+                            if (roundMap != null)
                             {
-                                // we have a decider map
-                                var deciderMap = CurrentMatch.Value.Round.Value?.Beatmaps
-                                                             .FirstOrDefault(b => CurrentMatch.Value.PicksBans.All(p => p.BeatmapID != b.ID));
-
-                                Logger.Log($"{nameof(updateStateLazer)}: on decider map?: {deciderMap != null}");
-
-                                // mark match as completed, as we've played the decider map
-                                if (deciderMap?.ID == mapId)
-                                    CurrentMatch.Value.Completed.Value = true;
+                                CurrentMatch.Value.MapScores[roundMap.SlotName] = new Tuple<long, long>(lazerIpc.Score1.Value, lazerIpc.Score2.Value);
                             }
                         }
                     }

--- a/osu.Game.Tournament/Screens/Gameplay/GameplayScreen.cs
+++ b/osu.Game.Tournament/Screens/Gameplay/GameplayScreen.cs
@@ -60,6 +60,7 @@ namespace osu.Game.Tournament.Screens.Gameplay
                 header = new MatchHeader
                 {
                     ShowLogo = false,
+                    ShowMatchRound = false,
                 },
                 new Container
                 {

--- a/osu.Game.Tournament/Screens/Gameplay/GameplayScreen.cs
+++ b/osu.Game.Tournament/Screens/Gameplay/GameplayScreen.cs
@@ -263,38 +263,32 @@ namespace osu.Game.Tournament.Screens.Gameplay
 
                     if (LadderInfo.CumulativeScore.Value)
                     {
-                        // CurrentMatch.Value.Team1Score.Value += lazerIpc.Score1.Value;
-                        // CurrentMatch.Value.Team2Score.Value += lazerIpc.Score2.Value;
-
                         int mapId = lazerIpc.Beatmap.Value?.OnlineID ?? 0;
 
                         if (mapId > 0)
                         {
-                            // int pickBansCount = LadderInfo.CurrentMatch.Value?.PicksBans.Count ?? 0;
-                            // int poolSize = LadderInfo.CurrentMatch.Value?.Round.Value?.Beatmaps.Count ?? -1;
-                            //
-                            // bool eligibleForWin = pickBansCount + 1 == poolSize;
-                            //
-                            // Logger.Log($"{nameof(updateStateLazer)}: pickban#: {pickBansCount} | poolSize: {poolSize} | can win?: {eligibleForWin}");
-                            //
-                            // if (eligibleForWin)
-                            // {
-                            //     // we have a decider map
-                            //     var deciderMap = CurrentMatch.Value.Round.Value?.Beatmaps
-                            //                                  .FirstOrDefault(b => CurrentMatch.Value.PicksBans.All(p => p.BeatmapID != b.ID));
-                            //
-                            //     Logger.Log($"{nameof(updateStateLazer)}: on decider map?: {deciderMap != null}");
-                            //
-                            //     // mark match as completed, as we've played the decider map
-                            //     if (deciderMap?.ID == mapId)
-                            //         CurrentMatch.Value.Completed.Value = true;
-                            // }
-
                             var roundMap = CurrentMatch.Value.Round.Value?.Beatmaps.FirstOrDefault(b => b.ID == mapId);
 
                             if (roundMap != null)
                             {
                                 CurrentMatch.Value.MapScores[roundMap.SlotName] = new Tuple<long, long>(lazerIpc.Score1.Value, lazerIpc.Score2.Value);
+
+                                // The following is ugly, but it will do for now.
+                                var currentSet = MatchSet.FindSetByMapId(CurrentMatch.Value, mapId);
+
+                                if (currentSet != null && mapId == currentSet.Map2Id.Value)
+                                {
+                                    // add point to match, the set is complete
+                                    var scores = currentSet.GetSetScores(CurrentMatch.Value);
+
+                                    if (scores != null)
+                                    {
+                                        if (scores.Item1 > scores.Item2)
+                                            CurrentMatch.Value.Team1Score.Value++;
+                                        else
+                                            CurrentMatch.Value.Team2Score.Value++;
+                                    }
+                                }
                             }
                         }
                     }

--- a/osu.Game.Tournament/Screens/Gameplay/GameplayScreen.cs
+++ b/osu.Game.Tournament/Screens/Gameplay/GameplayScreen.cs
@@ -276,17 +276,20 @@ namespace osu.Game.Tournament.Screens.Gameplay
                                 // The following is ugly, but it will do for now.
                                 var currentSet = MatchSet.FindSetByMapId(CurrentMatch.Value, mapId);
 
-                                if (currentSet != null && mapId == currentSet.Map2Id.Value)
+                                if (currentSet != null)
                                 {
-                                    // add point to match, the set is complete
-                                    var scores = currentSet.GetSetScores(CurrentMatch.Value);
-
-                                    if (scores != null)
+                                    if ((currentSet.IsTiebreaker == false && mapId == currentSet.Map2Id.Value) || mapId == currentSet.Map3Id.Value)
                                     {
-                                        if (scores.Item1 > scores.Item2)
-                                            CurrentMatch.Value.Team1Score.Value++;
-                                        else
-                                            CurrentMatch.Value.Team2Score.Value++;
+                                        // add point to match, the set is complete
+                                        var scores = currentSet.GetSetScores(CurrentMatch.Value);
+
+                                        if (scores != null)
+                                        {
+                                            if (scores.Item1 > scores.Item2)
+                                                CurrentMatch.Value.Team1Score.Value++;
+                                            else
+                                                CurrentMatch.Value.Team2Score.Value++;
+                                        }
                                     }
                                 }
                             }

--- a/osu.Game.Tournament/Screens/Ladder/Components/DrawableMatchTeam.cs
+++ b/osu.Game.Tournament/Screens/Ladder/Components/DrawableMatchTeam.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Tournament.Screens.Ladder.Components
 {
     public partial class DrawableMatchTeam : DrawableTournamentTeam, IHasContextMenu
     {
-        protected partial class MatchTeamCumulativeScoreCounter : CommaSeparatedScoreCounter
+        public partial class MatchTeamCumulativeScoreCounter : CommaSeparatedScoreCounter
         {
             public OsuSpriteText DisplayedSpriteText = null!;
 

--- a/osu.Game.Tournament/Screens/MapPool/MapPoolScreen.cs
+++ b/osu.Game.Tournament/Screens/MapPool/MapPoolScreen.cs
@@ -253,13 +253,7 @@ namespace osu.Game.Tournament.Screens.MapPool
 
             // if bans have already been placed, beatmap changes result in a selection being made automatically
             if (beatmap.NewValue?.OnlineID > 0)
-            {
-                Logger.Log($"beatmap changed to {beatmap.NewValue.OnlineID}, adding to pool");
-
                 addForBeatmap(beatmap.NewValue.OnlineID);
-            }
-
-            Logger.Log($"beatmap onlineid is leq 0 , not addingForMeatmap");
         }
 
         private void setMode(TeamColour colour, ChoiceType choiceType)

--- a/osu.Game.Tournament/Screens/MapPool/MapPoolScreen.cs
+++ b/osu.Game.Tournament/Screens/MapPool/MapPoolScreen.cs
@@ -325,57 +325,39 @@ namespace osu.Game.Tournament.Screens.MapPool
             static Color4 setColour(bool active) => active ? Color4.White : Color4.Gray;
         }
 
-        // LGA bans (week 1)
-        // The first player (A) will ban one beatmap, followed by the second player (B) also banning a beatmap: AB
-        // Players will pick two beatmaps respecting the following order: BAAB
-        // Both players will ban two maps, as such: ABBA
-        // The last beatmap remaining in the pool will be used as the 5th pick for the match.
-        //
-        // LGA bans (week 2)
-        // The first player (A) will ban one beatmap, followed by the second player (B) also banning a beatmap: AB (1)
-        // Players will pick two beatmaps respecting the following order: BAAB (2)
-        // Both players will ban two beatmaps, as such: ABBA (3)
-        // Both players will pick one beatmap: AB (4)
-        // Both players will ban one beatmap: BA (5)
-        // The last beatmap remaining in the pool will be used as the 7th pick for the match. (6)
-        // Exceptionally, for the Losers' Bracket Finals and Grand Finals, steps 5 and 6 will not be applied, and the last pick will be an osu! original beatmap, to be released at match time.
-        //
-        // Ban  AB
-        // Pick BAAB
-        // Ban  BAAB
-        // Pick AB
-        // Ban  BA
-        //
-        // boils down to ABBAAB(BA) then ABBAABBA
         private void setNextMode()
         {
+            if (CurrentMatch.Value?.Round.Value == null)
+                return;
+
             bool[] shouldBanAtCount =
             {
                 true, true,
-                false, false, false, false,
-                true, true, true, true,
+                // protects happen here
+                true, true,
+                false, false, // set 1
                 false, false,
-                true, true
+                false, false,
+                false, false,
+                false, false, // TB set
             };
 
             TeamColour[] teamColourOrder =
             {
+                TeamColour.Red, TeamColour.Blue, // ban phase 1
+                TeamColour.Blue, TeamColour.Red, // ban phase 2
+                TeamColour.Red, TeamColour.Blue, // set 1
+                TeamColour.Blue, TeamColour.Red,
                 TeamColour.Red, TeamColour.Blue,
-                TeamColour.Blue, TeamColour.Red, TeamColour.Red, TeamColour.Blue,
-                TeamColour.Blue, TeamColour.Red, TeamColour.Red, TeamColour.Blue,
-                TeamColour.Red, TeamColour.Blue,
-                TeamColour.Blue, TeamColour.Red
+                TeamColour.Blue, TeamColour.Red,
+                TeamColour.Red, TeamColour.Blue, // TB set
             };
-
-            if (CurrentMatch.Value?.Round.Value == null)
-                return;
 
             int pickedAndBannedCount = CurrentMatch.Value.PicksBans.Count;
             bool shouldBan = pickedAndBannedCount < shouldBanAtCount.Length && shouldBanAtCount[pickedAndBannedCount];
             TeamColour nextColour = pickedAndBannedCount < teamColourOrder.Length ? teamColourOrder[pickedAndBannedCount] : TeamColour.Red;
 
-            // setMode(nextColour, shouldBan ? ChoiceType.Ban : ChoiceType.Pick);
-            setMode(nextColour, ChoiceType.Pick);
+            setMode(nextColour, shouldBan ? ChoiceType.Ban : ChoiceType.Pick);
         }
 
         protected override bool OnMouseDown(MouseDownEvent e)

--- a/osu.Game.Tournament/Screens/MapPool/MapPoolScreen.cs
+++ b/osu.Game.Tournament/Screens/MapPool/MapPoolScreen.cs
@@ -60,10 +60,12 @@ namespace osu.Game.Tournament.Screens.MapPool
                 new MatchHeader
                 {
                     ShowScores = true,
+                    ShowLogo = false,
+                    ShowMatchRound = false,
                 },
                 new GridContainer
                 {
-                    Y = 170,
+                    Y = 90,
                     X = 0f,
                     Anchor = Anchor.TopLeft,
                     RelativePositionAxes = Axes.X,

--- a/osu.Game.Tournament/Screens/MapPool/MapPoolScreen.cs
+++ b/osu.Game.Tournament/Screens/MapPool/MapPoolScreen.cs
@@ -344,7 +344,7 @@ namespace osu.Game.Tournament.Screens.MapPool
 
             TeamColour[] teamColourOrder =
             {
-                TeamColour.Red, TeamColour.Blue, // ban phase 1
+                TeamColour.Blue, TeamColour.Red, // ban phase 1
                 TeamColour.Blue, TeamColour.Red, // ban phase 2
                 TeamColour.Red, TeamColour.Blue, // set 1
                 TeamColour.Blue, TeamColour.Red,

--- a/osu.Game.Tournament/Screens/MapPool/MapPoolScreen.cs
+++ b/osu.Game.Tournament/Screens/MapPool/MapPoolScreen.cs
@@ -252,8 +252,10 @@ namespace osu.Game.Tournament.Screens.MapPool
                 return;
 
             // if bans have already been placed, beatmap changes result in a selection being made automatically
-            if (beatmap.NewValue?.OnlineID > 0)
-                addForBeatmap(beatmap.NewValue.OnlineID);
+            if (!(beatmap.NewValue?.OnlineID > 0)) return;
+
+            addForBeatmap(beatmap.NewValue.OnlineID);
+            updatePickedDisplay();
         }
 
         private void setMode(TeamColour colour, ChoiceType choiceType)

--- a/osu.Game.Tournament/Screens/MapPool/MapPoolScreen.cs
+++ b/osu.Game.Tournament/Screens/MapPool/MapPoolScreen.cs
@@ -414,6 +414,8 @@ namespace osu.Game.Tournament.Screens.MapPool
             if (CurrentMatch.Value == null)
                 return;
 
+            const int tiebreaker_set_index = 1;
+
             var picks = CurrentMatch.Value.PicksBans.Where(pb => pb.Type == ChoiceType.Pick).ToList();
             var sets = CurrentMatch.Value.Sets;
 
@@ -429,7 +431,7 @@ namespace osu.Game.Tournament.Screens.MapPool
 
                 if (sets.Count - 1 < setIndex)
                 {
-                    sets.Add(currentSet = new MatchSet());
+                    sets.Add(currentSet = new MatchSet(setIndex == tiebreaker_set_index));
                 }
                 else
                 {

--- a/osu.Game.Tournament/Screens/MapPool/MapPoolScreen.cs
+++ b/osu.Game.Tournament/Screens/MapPool/MapPoolScreen.cs
@@ -1,14 +1,12 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-// using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Events;
 using osu.Framework.Logging;
 using osu.Framework.Threading;
@@ -448,15 +446,16 @@ namespace osu.Game.Tournament.Screens.MapPool
             if (CurrentMatch.Value?.Round.Value == null)
                 return;
 
-            var totalSets = CurrentMatch.Value.PicksBans.Count / 2 + 1;
+            var picks = CurrentMatch.Value.PicksBans.Where(pb => pb.Type == ChoiceType.Pick).ToList();
+            int setsCount = (picks.Count + 1) / 2; // number of sets to display
 
-            if (setsFlow.Count > totalSets)
+            if (setsFlow.Count > setsCount)
             {
-                // todo: track sets and remove one by one instead of clearing whole flow
+                // todo: track sets and remove one by one instead of clearing whole flow?
                 setsFlow.Clear();
             }
 
-            while (setsFlow.Count < totalSets)
+            while (setsFlow.Count < setsCount)
             {
                 setsFlow.Add(new TournamentSetPanel
                 {
@@ -464,6 +463,24 @@ namespace osu.Game.Tournament.Screens.MapPool
                     Origin = Anchor.TopCentre,
                     Height = 48,
                 });
+            }
+
+            for (int i = 0; i < picks.Count; i++)
+            {
+                int setIndex = i % 2; // slot index into the set (0 or 1)
+                var currentSet = setsFlow[i / 2];
+                var matchPickBan = picks[i];
+
+                Logger.Log($"Hello, we got a pick: {matchPickBan.Team} {matchPickBan.Type} {matchPickBan.BeatmapID} (setting set {setsCount - 1} slot {setIndex} to {matchPickBan.BeatmapID})");
+
+                if (setIndex == 0)
+                {
+                    currentSet.Map1Id.Value = matchPickBan.BeatmapID;
+                    currentSet.Map2Id.Value = 0;
+                    continue;
+                }
+
+                currentSet.Map2Id.Value = matchPickBan.BeatmapID;
             }
 
             // if (CurrentMatch.Value?.Round.Value == null)

--- a/osu.Game.Tournament/Screens/MapPool/MapPoolScreen.cs
+++ b/osu.Game.Tournament/Screens/MapPool/MapPoolScreen.cs
@@ -244,29 +244,22 @@ namespace osu.Game.Tournament.Screens.MapPool
             if (CurrentMatch.Value?.Round.Value == null)
                 return;
 
-            if (setsFlow.Count == 0)
+            // TODO: LGA does BBPPBBPPPP.... there's a pick phase between two ban phases
+
+            int totalBansRequired = CurrentMatch.Value.Round.Value.BanCount.Value * 2;
+
+            if (CurrentMatch.Value.PicksBans.Count(p => p.Type == ChoiceType.Ban) < totalBansRequired)
                 return;
 
-            if (beatmap.NewValue?.OnlineID == null)
-                return;
+            // if bans have already been placed, beatmap changes result in a selection being made automatically
+            if (beatmap.NewValue?.OnlineID > 0)
+            {
+                Logger.Log($"beatmap changed to {beatmap.NewValue.OnlineID}, adding to pool");
 
-            // var currentPanel = pickedMapsFlow.FirstOrDefault(p => p.Beatmap?.OnlineID == beatmap.NewValue.OnlineID);
-            // if (currentPanel == null) return;
-            //
-            // var parentSpacePosition = currentPanel.ToSpaceOfOtherDrawable(currentPanel.OriginPosition, Parent!);
-            // var offsetPosition = parentSpacePosition +
-            //                      new Vector2(-currentPanel.DrawWidth / 2 - currentMapIndicator.DrawWidth / 2 - 16,
-            //                          currentPanel.DrawHeight / 2 - currentMapIndicator.DrawHeight / 2);
-            //
-            // if (currentMapIndicator.Alpha == 0)
-            // {
-            //     currentMapIndicator.MoveTo(offsetPosition);
-            //     currentMapIndicator.FadeInFromZero(500);
-            // }
-            // else
-            // {
-            //     currentMapIndicator.MoveTo(offsetPosition, 700, Easing.InOutExpo);
-            // }
+                addForBeatmap(beatmap.NewValue.OnlineID);
+            }
+
+            Logger.Log($"beatmap onlineid is leq 0 , not addingForMeatmap");
         }
 
         private void setMode(TeamColour colour, ChoiceType choiceType)

--- a/osu.Game.Tournament/Screens/Schedule/ScheduleScreen.cs
+++ b/osu.Game.Tournament/Screens/Schedule/ScheduleScreen.cs
@@ -285,7 +285,6 @@ namespace osu.Game.Tournament.Screens.Schedule
                     {
                         Anchor = Anchor.TopRight,
                         Origin = Anchor.TopLeft,
-                        Colour = OsuColour.Gray(0.7f),
                         Alpha = conditional ? 0.6f : 1,
                         Font = OsuFont.Torus,
                         Margin = new MarginPadding { Horizontal = 10, Vertical = 5 },
@@ -294,7 +293,6 @@ namespace osu.Game.Tournament.Screens.Schedule
                     {
                         Anchor = Anchor.BottomRight,
                         Origin = Anchor.BottomLeft,
-                        Colour = OsuColour.Gray(0.7f),
                         Alpha = conditional ? 0.6f : 1,
                         Margin = new MarginPadding { Horizontal = 10, Vertical = 5 },
                         Text = match.Date.Value.ToUniversalTime().ToString("HH:mm UTC") + (conditional ? " (conditional)" : "")

--- a/osu.Game/Graphics/UserInterface/CommaSeparatedScoreCounter.cs
+++ b/osu.Game/Graphics/UserInterface/CommaSeparatedScoreCounter.cs
@@ -1,24 +1,28 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Localisation;
 using osu.Game.Graphics.Sprites;
+using System.Numerics;
 
 namespace osu.Game.Graphics.UserInterface
 {
-    public abstract partial class CommaSeparatedScoreCounter : RollingCounter<double>
+    public abstract partial class CommaSeparatedScoreCounter<T> : RollingCounter<T> where T : struct, INumber<T>, IConvertible
     {
         protected override double RollingDuration => 1000;
         protected override Easing RollingEasing => Easing.Out;
 
-        protected override double GetProportionalDuration(double currentValue, double newValue) =>
-            currentValue > newValue ? currentValue - newValue : newValue - currentValue;
+        protected override double GetProportionalDuration(T currentValue, T newValue) =>
+            Convert.ToDouble(currentValue > newValue ? currentValue - newValue : newValue - currentValue);
 
-        protected override LocalisableString FormatCount(double count) => ((long)count).ToLocalisableString(@"N0");
+        protected override LocalisableString FormatCount(T count) => count.ToLocalisableString(@"N0");
 
         protected override OsuSpriteText CreateSpriteText()
             => base.CreateSpriteText().With(s => s.Font = s.Font.With(fixedWidth: true));
     }
+
+    public abstract partial class CommaSeparatedScoreCounter : CommaSeparatedScoreCounter<double>;
 }

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorScreen.cs
@@ -183,6 +183,8 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
         {
             base.LoadComplete();
 
+            BackButtonVisibility.Value = false;
+
             masterClockContainer.Reset();
 
             // Start with adjustments from the first player to keep a sane state.


### PR DESCRIPTION
- matches are a first to 3 (best of 5)
- a point is won after a set is played
- a set consists of two maps
- the player with the highest sum of scores between the two maps wins the set

in addition to the above score tracking,
- the current cumulative score of the set is shown in the gameplay screen
- the sets are displayed in the mappool screen

this PR also includes some code quality changes w.r.t. calculating slot names, which affects the mappool showcase screen (although not in a visible way)

----

TODO:
- [x] add a way to edit map scores (added in b205ff32)
- [x] score delta chevron only points left (fixed in f86437a7)
- [x] better styling/alignment of cumulative score number in gameplay screen
- [x] sets not updating when map is selected via autopick (fixed in 568949a)
- [x] set 5 is a set with 3 maps (TB, score is sum of 3 maps) (02eb24f0)
- [ ] (low prio) update set display for TB type? (not even sure how to display a set with 3 maps, i'll think about it later)
- [x] mappool overflow #68 (fixed by ca6a227)
- [x] LGA pick order (BBPPBBPPPP) (added in 5c5fb9ab and 3e346279)