### PR TITLE
fix lobby chat not updating while sitting in results screen

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Multiplayer/GameplayChatDisplay.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/GameplayChatDisplay.cs
@@ -39,6 +39,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         {
             RelativeSizeAxes = Axes.X;
             Background.Alpha = 0.2f;
+            AlwaysPresent = true;
         }
 
         [BackgroundDependencyLoader]

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorScreen.cs
@@ -53,6 +53,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
 
         private readonly PlayerArea[] instances;
         private MasterGameplayClockContainer masterClockContainer = null!;
+        private FillFlowContainer leaderboardFlow = null!; // now used to load invisible chat component
         private SpectatorSyncManager syncManager = null!;
         private PlayerGrid grid = null!;
         private TournamentSpectatorStatisticsTracker statisticsTracker = null!;
@@ -118,8 +119,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
                                     {
                                         new Drawable[]
                                         {
-                                            // leaderboardFlow = new FillFlowContainer
-                                            new FillFlowContainer
+                                            leaderboardFlow = new FillFlowContainer
                                             {
                                                 Anchor = Anchor.CentreLeft,
                                                 Origin = Anchor.CentreLeft,
@@ -172,11 +172,12 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
             //         }, scoreDisplayContainer.Add);
             //     }
             // });
-            //
-            // LoadComponentAsync(new GameplayChatDisplay(room)
-            // {
-            //     Expanded = { Value = true },
-            // }, chat => leaderboardFlow.Insert(1, chat));
+
+            LoadComponentAsync(new GameplayChatDisplay(room)
+            {
+                Expanded = { Value = true },
+                Alpha = 0
+            }, chat => leaderboardFlow.Insert(0, chat));
         }
 
         protected override void LoadComplete()


### PR DESCRIPTION
adds a hidden chat component in gameplay to keep chat flowing to the tourney overlay

closes #73 