### PR TITLE
fix cumulative score go to 0 when autopick switches to 2nd map in set

### DIFF
--- a/osu.Game.Tournament/Screens/Gameplay/Components/TeamScoreCumulative.cs
+++ b/osu.Game.Tournament/Screens/Gameplay/Components/TeamScoreCumulative.cs
@@ -45,7 +45,8 @@ namespace osu.Game.Tournament.Screens.Gameplay.Components
                 },
                 true);
 
-            beatmap.BindValueChanged(_ => updateCumulativeScore(), true);
+            // delay cumulative score update until sets are updated
+            beatmap.BindValueChanged(_ => Schedule(updateCumulativeScore), true);
         }
 
         protected override void LoadComplete()


### PR DESCRIPTION
set lookup logic (called by score update) expects the sets to be up to date, score update and set update logic are fired from the same bindable change event. when beatmap changes, set lookup sometimes run before sets are updated so scores reset to 0