### PR TITLE
wait until players are loaded before updating state IPC to playing

### DIFF
--- a/osu.Game/TournamentIpc/TournamentFileBasedIPC.cs
+++ b/osu.Game/TournamentIpc/TournamentFileBasedIPC.cs
@@ -234,7 +234,10 @@ namespace osu.Game.TournamentIpc
 
             switch (newRoomState)
             {
+                // don't transition to Playing state while waiting for players to load
                 case MultiplayerRoomState.WaitingForLoad:
+                    break;
+
                 case MultiplayerRoomState.Playing:
                     TourneyState.Value = TournamentIpc.TourneyState.Playing;
                     break;


### PR DESCRIPTION
overlay now waits until players are loaded before switching to gameplay screen

https://github.com/user-attachments/assets/dfd188a7-d4cd-4f92-a52c-65d086f4372d

