### PR TITLE
Adjust layout and scaling of TournamentBeatmapPanel inner drawables

### DIFF
--- a/osu.Game.Tournament/Components/TournamentBeatmapPanel.cs
+++ b/osu.Game.Tournament/Components/TournamentBeatmapPanel.cs
@@ -14,7 +14,6 @@ using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.Drawables;
 using osu.Game.Graphics;
 using osu.Game.Tournament.Models;
-using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Game.Tournament.Components
@@ -42,8 +41,6 @@ namespace osu.Game.Tournament.Components
 
             Width = WIDTH;
             Height = HEIGHT;
-
-            Padding = new MarginPadding { Left = 8 };
         }
 
         [BackgroundDependencyLoader]
@@ -127,38 +124,35 @@ namespace osu.Game.Tournament.Components
                             Blending = BlendingParameters.Additive,
                             Alpha = 0,
                         },
+                        rightFlow = new FillFlowContainer
+                        {
+                            Anchor = Anchor.CentreRight,
+                            Origin = Anchor.CentreRight,
+                            Padding = new MarginPadding(10),
+                            RelativeSizeAxes = Axes.Y,
+                            Direction = FillDirection.Horizontal,
+                            Children = new Drawable[]
+                            {
+                                protectIcon = new TournamentProtectIcon
+                                {
+                                    Anchor = Anchor.CentreRight,
+                                    Origin = Anchor.CentreRight,
+                                    Width = 60,
+                                    Alpha = 1,
+                                    RelativeSizeAxes = Axes.Y,
+                                }
+                            }
+                        }
                     }
                 }
             });
 
-            AddInternal(rightFlow = new FillFlowContainer
-            {
-                Anchor = Anchor.CentreRight,
-                Origin = Anchor.CentreRight,
-                Margin = new MarginPadding(10),
-                RelativeSizeAxes = Axes.Y,
-                Direction = FillDirection.Horizontal,
-                Children = new Drawable[]
-                {
-                    protectIcon = new TournamentProtectIcon
-                    {
-                        Anchor = Anchor.CentreRight,
-                        Origin = Anchor.CentreRight,
-                        Width = 60,
-                        Scale = new Vector2(0.5f),
-                        Alpha = 1,
-                        RelativeSizeAxes = Axes.Y,
-                    }
-                }
-            });
-
-            if (!string.IsNullOrEmpty(mod))
+            if (!string.IsNullOrEmpty(mod) && !mod.Equals("NM", StringComparison.OrdinalIgnoreCase))
             {
                 rightFlow.Insert(-1, new TournamentModIcon(mod)
                 {
                     Anchor = Anchor.CentreRight,
                     Origin = Anchor.CentreRight,
-                    Margin = new MarginPadding(10),
                     Width = 60,
                     RelativeSizeAxes = Axes.Y,
                 });

--- a/osu.Game.Tournament/Components/TournamentProtectIcon.cs
+++ b/osu.Game.Tournament/Components/TournamentProtectIcon.cs
@@ -42,8 +42,8 @@ namespace osu.Game.Tournament.Components
             {
                 new Container
                 {
-                    Anchor = Anchor.CentreLeft,
-                    Origin = Anchor.CentreLeft,
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
                     Name = "main content",
                     Size = new Vector2(80), //to match mod icon size
                     Children = new Drawable[]
@@ -55,12 +55,14 @@ namespace osu.Game.Tournament.Components
                             Texture = textures.Get("Icons/BeatmapDetails/mod-icon"),
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,
+                            Scale = new Vector2(0.5f) // to match mod icon size
                         },
                         protectIcon = new SpriteIcon
                         {
                             Origin = Anchor.Centre,
                             Anchor = Anchor.Centre,
                             Size = new Vector2(40),
+                            Scale = new Vector2(0.5f),
                             Icon = FontAwesome.Solid.ShieldAlt,
                         },
                     }


### PR DESCRIPTION
AI-generated: Centralized anchors/origins in TournamentProtectIcon for better alignment and standardized scaling. Simplified flow container hierarchy in TournamentBeatmapPanel and refined mod icon logic to exclude "NM" cases.

Before:

![image](https://github.com/user-attachments/assets/6811f46e-2cc3-406a-b755-8183343c2175)

After: (imagine the same as above, but the gap is gone)