### PR TITLE
add SSR scoring system

### DIFF
--- a/osu.Game.Tournament.Tests/Screens/TestSceneGameplayScreen.cs
+++ b/osu.Game.Tournament.Tests/Screens/TestSceneGameplayScreen.cs
@@ -56,94 +56,15 @@ namespace osu.Game.Tournament.Tests.Screens
         }
 
         [Test]
-        public void TestScoreAddCumulative()
+        public void TestScoreCumulativeDeltaStable()
         {
-            AddStep("disable cumulative score", () => Ladder.CumulativeScore.Value = false);
             AddStep("enable cumulative score", () => Ladder.CumulativeScore.Value = true);
+            AddStep("use stable IPC", () => Ladder.UseLazerIpc.Value = false);
 
             createScreen();
             toggleWarmup();
-
-            AddStep("add set with maps 1 & 2", () => Ladder.CurrentMatch.Value!.Sets.Add(new MatchSet(false) { Map1Id = { Value = 1 }, Map2Id = { Value = 2 } }));
-            AddStep("add set with maps 3 & 4", () => Ladder.CurrentMatch.Value!.Sets.Add(new MatchSet(false) { Map1Id = { Value = 3 }, Map2Id = { Value = 4 } }));
-
-            for (int i = 0; i < 2; i++)
-            {
-                int i1 = i;
-                AddStep($"switch to map {i + 1}", () => LazerIPCInfo.Beatmap.Value = new TournamentBeatmap { OnlineID = i1 + 1 });
-
-                AddStep("set state: lobby", () => LazerIPCInfo.State.Value = TourneyState.Lobby);
-
-                AddStep("set state: playing", () => LazerIPCInfo.State.Value = TourneyState.Playing);
-
-                int iteration = i;
-                AddStep("add score", () =>
-                {
-                    LazerIPCInfo.Score1.Value = iteration == 0 ? 127_727 : 492_000;
-                    LazerIPCInfo.Score2.Value = iteration == 0 ? 63_000 : 613_727;
-                });
-                AddStep("set state: ranking", () => LazerIPCInfo.State.Value = TourneyState.Ranking);
-
-                AddWaitStep("wait a bit", 8);
-
-                AddStep("clear scores", () =>
-                {
-                    LazerIPCInfo.Score1.Value = 0;
-                    LazerIPCInfo.Score2.Value = 0;
-                });
-            }
-
-            AddStep("set state: lobby", () => LazerIPCInfo.State.Value = TourneyState.Lobby);
-            AddStep("switch to map 3", () => LazerIPCInfo.Beatmap.Value = new TournamentBeatmap { OnlineID = 3 });
-        }
-
-        [Test]
-        public void TestScoreAddCumulativeTiebreaker()
-        {
-            AddStep("disable cumulative score", () => Ladder.CumulativeScore.Value = false);
-            AddStep("enable cumulative score", () => Ladder.CumulativeScore.Value = true);
-
-            createScreen();
-            toggleWarmup();
-
-            AddStep("add tiebreaker set with maps 3, 4, 5", () => Ladder.CurrentMatch.Value!.Sets.Add(new MatchSet(true) { Map1Id = { Value = 1 }, Map2Id = { Value = 2 }, Map3Id = { Value = 3 } }));
 
             for (int i = 0; i < 3; i++)
-            {
-                int i1 = i;
-                AddStep($"switch to map {i + 1}", () => LazerIPCInfo.Beatmap.Value = new TournamentBeatmap { OnlineID = i1 + 1 });
-
-                AddStep("set state: lobby", () => LazerIPCInfo.State.Value = TourneyState.Lobby);
-
-                AddStep("set state: playing", () => LazerIPCInfo.State.Value = TourneyState.Playing);
-
-                int iteration = i + 1;
-                AddStep("add score", () =>
-                {
-                    LazerIPCInfo.Score1.Value = iteration * 1_000;
-                    LazerIPCInfo.Score2.Value = iteration;
-                });
-                AddStep("set state: ranking", () => LazerIPCInfo.State.Value = TourneyState.Ranking);
-
-                AddWaitStep("wait a bit", 8);
-
-                AddStep("clear scores", () =>
-                {
-                    LazerIPCInfo.Score1.Value = 0;
-                    LazerIPCInfo.Score2.Value = 0;
-                });
-            }
-        }
-
-        [Test]
-        public void TestScoreCumulativeDelta()
-        {
-            AddStep("enable cumulative score", () => Ladder.CumulativeScore.Value = true);
-
-            createScreen();
-            toggleWarmup();
-
-            for (int i = 0; i < 7; i++)
             {
                 AddStep($"add map {i + 1} results", () =>
                 {

--- a/osu.Game.Tournament/Screens/Gameplay/Components/TeamScore.cs
+++ b/osu.Game.Tournament/Screens/Gameplay/Components/TeamScore.cs
@@ -21,7 +21,6 @@ namespace osu.Game.Tournament.Screens.Gameplay.Components
         private readonly Bindable<long?> currentTeamScore = new Bindable<long?>();
         private readonly StarCounter counter;
         private Bindable<bool> useCumulativeScore = null!;
-        private Bindable<bool> useLazerIpc = null!;
 
         [Resolved]
         private LadderInfo ladder { get; set; } = null!;

--- a/osu.Game.Tournament/Screens/Gameplay/Components/TeamScore.cs
+++ b/osu.Game.Tournament/Screens/Gameplay/Components/TeamScore.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
@@ -19,6 +20,11 @@ namespace osu.Game.Tournament.Screens.Gameplay.Components
     {
         private readonly Bindable<long?> currentTeamScore = new Bindable<long?>();
         private readonly StarCounter counter;
+        private Bindable<bool> useCumulativeScore = null!;
+        private Bindable<bool> useLazerIpc = null!;
+
+        [Resolved]
+        private LadderInfo ladder { get; set; } = null!;
 
         public TeamScore(Bindable<long?> score, TeamColour colour, int count)
         {
@@ -35,6 +41,27 @@ namespace osu.Game.Tournament.Screens.Gameplay.Components
 
             currentTeamScore.BindValueChanged(scoreChanged);
             currentTeamScore.BindTo(score);
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            useCumulativeScore = ladder.CumulativeScore.GetBoundCopy();
+            useCumulativeScore.BindValueChanged(_ => updateVisibility());
+            ladder.UseLazerIpc.BindValueChanged(_ => updateVisibility(), true);
+        }
+
+        private void updateVisibility()
+        {
+            // if using stable IPC and Cumulative score is true, when don't show stars (SSR)
+            if (!ladder.UseLazerIpc.Value && useCumulativeScore.Value)
+            {
+                counter.Alpha = 0;
+                return;
+            }
+
+            counter.Alpha = 1;
         }
 
         private void scoreChanged(ValueChangedEvent<long?> score) => counter.Current = score.NewValue ?? 0;

--- a/osu.Game.Tournament/Screens/Gameplay/GameplayScreen.cs
+++ b/osu.Game.Tournament/Screens/Gameplay/GameplayScreen.cs
@@ -324,10 +324,24 @@ namespace osu.Game.Tournament.Screens.Gameplay
                 {
                     if (warmup.Value || CurrentMatch.Value == null) return;
 
-                    if (legacyIpc.Score1.Value > legacyIpc.Score2.Value)
-                        CurrentMatch.Value.Team1Score.Value++;
+                    if (LadderInfo.CumulativeScore.Value)
+                    {
+                        long scoreDelta = Math.Min(50_000, Math.Abs(legacyIpc.Score1.Value - legacyIpc.Score2.Value));
+
+                        if (legacyIpc.Score1.Value > legacyIpc.Score2.Value)
+                        {
+                            CurrentMatch.Value.Team1Score.Value += scoreDelta;
+                        }
+                        else
+                            CurrentMatch.Value.Team2Score.Value += scoreDelta;
+                    }
                     else
-                        CurrentMatch.Value.Team2Score.Value++;
+                    {
+                        if (legacyIpc.Score1.Value > legacyIpc.Score2.Value)
+                            CurrentMatch.Value.Team1Score.Value++;
+                        else
+                            CurrentMatch.Value.Team2Score.Value++;
+                    }
                 }
 
                 switch (LegacyState.Value)


### PR DESCRIPTION
> For example in a match where 3 maps required to be played: 
Map 1: Player A won by 200 points, current score is Player A | 200 - 0 | Player B
Map 2: Player B won by 300 points, current score is Player A | 200 - 300 | Player B
Map 3: Player A won by 400 points
=> Final score will be Player A | 600 - 300 | Player B and Player A wins

> [02:52]Lott: ye, however that score difference is limited to 50k
[02:52]Lott: so even if someone has a >50k lead, they'll only get 50k added into the sum